### PR TITLE
Add ID helper commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,25 @@ shorthand and do not require a local git checkout. Authentication and host
 resolution defer to the existing `gh` CLI configuration, including `GH_HOST` for
 GitHub Enterprise environments.
 
+### Helper commands for identifiers
+
+Emit minimal JSON for frequently needed identifiers:
+
+```sh
+# Locate the latest submitted review for a reviewer
+gh pr-review review latest-id --per_page 100 --page 1 --reviewer octocat owner/repo#42
+
+# List comment identifiers (with bodies) for a review
+gh pr-review comments ids --review_id 3531807471 --limit 50 owner/repo#42
+
+# Map a comment to its thread (or fetch by thread ID) with minimal schema
+gh pr-review threads find --comment_id 2582545223 owner/repo#42
+```
+
+Outputs are pure JSON with REST/GraphQL field names and include only fields that
+are present from the source APIs (no null placeholders). The `threads find`
+command always emits exactly `{ "id", "isResolved" }`.
+
 ## Development
 
 Run the test suite and linters locally with cgo disabled (matching the release build):

--- a/cmd/comments.go
+++ b/cmd/comments.go
@@ -41,6 +41,7 @@ func newCommentsCommand() *cobra.Command {
 	_ = cmd.MarkFlagRequired("list")
 
 	cmd.AddCommand(newCommentsReplyCommand(opts))
+	cmd.AddCommand(newCommentsIDsCommand())
 
 	return cmd
 }
@@ -145,4 +146,78 @@ func runCommentsReply(cmd *cobra.Command, opts *commentsReplyOptions) error {
 		return err
 	}
 	return encodeJSON(cmd, reply)
+}
+
+func newCommentsIDsCommand() *cobra.Command {
+	opts := &commentsIDsOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "ids [<number> | <url> | <owner>/<repo>#<number>]",
+		Short: "List review comment identifiers with text",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				opts.Selector = args[0]
+			}
+			return runCommentsIDs(cmd, opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Repo, "repo", "R", "", "Repository in 'owner/repo' format")
+	cmd.Flags().IntVar(&opts.Pull, "pr", 0, "Pull request number")
+	cmd.Flags().Int64Var(&opts.ReviewID, "review_id", 0, "Review identifier to target")
+	cmd.Flags().BoolVar(&opts.Latest, "latest", false, "Resolve the latest submitted review (defaults to authenticated reviewer)")
+	cmd.Flags().StringVar(&opts.Reviewer, "reviewer", "", "Reviewer login when using --latest")
+	cmd.Flags().IntVar(&opts.Limit, "limit", 0, "Maximum number of comments to emit (0 = all)")
+	cmd.Flags().IntVar(&opts.PerPage, "per_page", 0, "Number of comments per REST request")
+	cmd.Flags().IntVar(&opts.Page, "page", 0, "Starting REST page index")
+
+	return cmd
+}
+
+type commentsIDsOptions struct {
+	Repo     string
+	Pull     int
+	Selector string
+	ReviewID int64
+	Latest   bool
+	Reviewer string
+	Limit    int
+	PerPage  int
+	Page     int
+}
+
+func runCommentsIDs(cmd *cobra.Command, opts *commentsIDsOptions) error {
+	if opts.ReviewID == 0 && !opts.Latest {
+		return errors.New("use --review_id or --latest to select a review")
+	}
+	if opts.ReviewID > 0 && opts.Latest {
+		return errors.New("specify either --review_id or --latest, not both")
+	}
+
+	selector, err := resolver.NormalizeSelector(opts.Selector, opts.Pull)
+	if err != nil {
+		return err
+	}
+
+	hostEnv := os.Getenv("GH_HOST")
+	identity, err := resolver.Resolve(selector, opts.Repo, hostEnv)
+	if err != nil {
+		return err
+	}
+
+	service := comments.NewService(apiClientFactory(identity.Host))
+	entries, err := service.IDs(identity, comments.IDsOptions{
+		ReviewID: opts.ReviewID,
+		Latest:   opts.Latest,
+		Reviewer: opts.Reviewer,
+		Limit:    opts.Limit,
+		PerPage:  opts.PerPage,
+		Page:     opts.Page,
+	})
+	if err != nil {
+		return err
+	}
+
+	return encodeJSON(cmd, entries)
 }

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -44,6 +44,8 @@ func newReviewCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.Body, "body", "", "Comment or review body")
 	cmd.Flags().StringVar(&opts.Event, "event", opts.Event, "Review submission event (APPROVE, COMMENT, REQUEST_CHANGES)")
 
+	cmd.AddCommand(newReviewLatestIDCommand())
+
 	return cmd
 }
 
@@ -182,4 +184,62 @@ func normalizeEvent(event string) (string, error) {
 	default:
 		return "", fmt.Errorf("invalid event %q: must be APPROVE, COMMENT, or REQUEST_CHANGES", event)
 	}
+}
+
+func newReviewLatestIDCommand() *cobra.Command {
+	opts := &reviewLatestOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "latest-id [<number> | <url> | <owner>/<repo>#<number>]",
+		Short: "Show the latest submitted review identifier for a reviewer",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				opts.Selector = args[0]
+			}
+			return runReviewLatestID(cmd, opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Repo, "repo", "R", "", "Repository in 'owner/repo' format")
+	cmd.Flags().IntVar(&opts.Pull, "pr", 0, "Pull request number")
+	cmd.Flags().StringVar(&opts.Reviewer, "reviewer", "", "Reviewer login (defaults to authenticated user)")
+	cmd.Flags().IntVar(&opts.PerPage, "per_page", 0, "Number of reviews per page (REST)")
+	cmd.Flags().IntVar(&opts.Page, "page", 0, "Page index for the initial REST request")
+
+	return cmd
+}
+
+type reviewLatestOptions struct {
+	Repo     string
+	Pull     int
+	Selector string
+	Reviewer string
+	PerPage  int
+	Page     int
+}
+
+func runReviewLatestID(cmd *cobra.Command, opts *reviewLatestOptions) error {
+	selector, err := resolver.NormalizeSelector(opts.Selector, opts.Pull)
+	if err != nil {
+		return err
+	}
+
+	hostEnv := os.Getenv("GH_HOST")
+	identity, err := resolver.Resolve(selector, opts.Repo, hostEnv)
+	if err != nil {
+		return err
+	}
+
+	service := reviewsvc.NewService(apiClientFactory(identity.Host))
+	summary, err := service.LatestSubmitted(identity, reviewsvc.LatestOptions{
+		Reviewer: opts.Reviewer,
+		PerPage:  opts.PerPage,
+		Page:     opts.Page,
+	})
+	if err != nil {
+		return err
+	}
+
+	return encodeJSON(cmd, summary)
 }

--- a/cmd/threads.go
+++ b/cmd/threads.go
@@ -20,6 +20,7 @@ func newThreadsCommand() *cobra.Command {
 	cmd.AddCommand(newThreadsListCommand())
 	cmd.AddCommand(newThreadsResolveCommand())
 	cmd.AddCommand(newThreadsUnresolveCommand())
+	cmd.AddCommand(newThreadsFindCommand())
 
 	return cmd
 }
@@ -186,5 +187,70 @@ func runThreadsMutation(cmd *cobra.Command, opts *threadsMutationOptions, resolv
 	if err != nil {
 		return err
 	}
+	return encodeJSON(cmd, result)
+}
+
+func newThreadsFindCommand() *cobra.Command {
+	opts := &threadsFindOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "find [<number> | <url> | <owner>/<repo>#<number>]",
+		Short: "Locate a review thread by thread or comment identifier",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				opts.Selector = args[0]
+			}
+			return runThreadsFind(cmd, opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Repo, "repo", "R", "", "Repository in 'owner/repo' format")
+	cmd.Flags().IntVar(&opts.Pull, "pr", 0, "Pull request number")
+	cmd.Flags().StringVar(&opts.ThreadID, "thread_id", "", "GraphQL thread node ID")
+	cmd.Flags().Int64Var(&opts.CommentID, "comment_id", 0, "Review comment identifier")
+
+	return cmd
+}
+
+type threadsFindOptions struct {
+	Repo      string
+	Pull      int
+	Selector  string
+	ThreadID  string
+	CommentID int64
+}
+
+func runThreadsFind(cmd *cobra.Command, opts *threadsFindOptions) error {
+	threadIDProvided := strings.TrimSpace(opts.ThreadID) != ""
+	commentProvided := opts.CommentID > 0
+
+	switch {
+	case threadIDProvided && commentProvided:
+		return errors.New("specify either --thread_id or --comment_id, not both")
+	case !threadIDProvided && !commentProvided:
+		return errors.New("must provide --thread_id or --comment_id")
+	}
+
+	selector, err := resolver.NormalizeSelector(opts.Selector, opts.Pull)
+	if err != nil {
+		return err
+	}
+
+	hostEnv := os.Getenv("GH_HOST")
+	identity, err := resolver.Resolve(selector, opts.Repo, hostEnv)
+	if err != nil {
+		return err
+	}
+
+	service := threads.NewService(apiClientFactory(identity.Host))
+	result, err := service.Find(identity, threads.FindOptions{
+		ThreadID:  opts.ThreadID,
+		CommentID: opts.CommentID,
+	})
+	if err != nil {
+		return err
+	}
+
 	return encodeJSON(cmd, result)
 }

--- a/internal/comments/ids.go
+++ b/internal/comments/ids.go
@@ -1,0 +1,141 @@
+package comments
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/Agyn-sandbox/gh-pr-review/internal/resolver"
+)
+
+// IDsOptions configures comment identifier listings.
+type IDsOptions struct {
+	ReviewID int64
+	Latest   bool
+	Reviewer string
+	Limit    int
+	PerPage  int
+	Page     int
+}
+
+// CommentReference exposes a minimal comment payload with identifiers and metadata.
+type CommentReference struct {
+	ID                int64          `json:"id"`
+	Body              string         `json:"body"`
+	User              *CommentAuthor `json:"user,omitempty"`
+	AuthorAssociation string         `json:"author_association,omitempty"`
+	CreatedAt         string         `json:"created_at,omitempty"`
+	UpdatedAt         string         `json:"updated_at,omitempty"`
+	HTMLURL           string         `json:"html_url,omitempty"`
+	Path              string         `json:"path,omitempty"`
+	Line              *int           `json:"line,omitempty"`
+}
+
+// CommentAuthor represents the user who authored a comment.
+type CommentAuthor struct {
+	Login string `json:"login,omitempty"`
+	ID    int64  `json:"id,omitempty"`
+}
+
+// IDs returns comment identifiers (and selected metadata) for the requested review.
+func (s *Service) IDs(pr resolver.Identity, opts IDsOptions) ([]CommentReference, error) {
+	if opts.Limit < 0 {
+		return nil, errors.New("limit must be non-negative")
+	}
+
+	reviewID, err := s.resolveReviewID(pr, ListOptions{ReviewID: opts.ReviewID, Latest: opts.Latest, Reviewer: opts.Reviewer})
+	if err != nil {
+		return nil, err
+	}
+
+	perPage := clampIDsPerPage(opts.PerPage)
+	page := opts.Page
+	if page <= 0 {
+		page = 1
+	}
+
+	limit := opts.Limit
+	var results []CommentReference
+
+	for current := page; ; current++ {
+		var chunk []restComment
+		params := map[string]string{
+			"per_page": strconv.Itoa(perPage),
+			"page":     strconv.Itoa(current),
+		}
+		path := fmt.Sprintf("repos/%s/%s/pulls/%d/reviews/%d/comments", pr.Owner, pr.Repo, pr.Number, reviewID)
+		if err := s.API.REST("GET", path, params, nil, &chunk); err != nil {
+			return nil, err
+		}
+
+		if len(chunk) == 0 {
+			break
+		}
+
+		for _, comment := range chunk {
+			entry := CommentReference{ID: comment.ID, Body: comment.Body}
+
+			login := strings.TrimSpace(comment.User.Login)
+			if login != "" || comment.User.ID != 0 {
+				entry.User = &CommentAuthor{Login: login, ID: comment.User.ID}
+			}
+			if assoc := strings.TrimSpace(comment.AuthorAssociation); assoc != "" {
+				entry.AuthorAssociation = assoc
+			}
+			if created := strings.TrimSpace(comment.CreatedAt); created != "" {
+				entry.CreatedAt = created
+			}
+			if updated := strings.TrimSpace(comment.UpdatedAt); updated != "" {
+				entry.UpdatedAt = updated
+			}
+			if url := strings.TrimSpace(comment.HTMLURL); url != "" {
+				entry.HTMLURL = url
+			}
+			if path := strings.TrimSpace(comment.Path); path != "" {
+				entry.Path = path
+			}
+			if comment.Line != nil {
+				line := *comment.Line
+				entry.Line = &line
+			}
+
+			results = append(results, entry)
+			if limit > 0 && len(results) >= limit {
+				return results[:limit], nil
+			}
+		}
+
+		if len(chunk) < perPage {
+			break
+		}
+	}
+
+	return results, nil
+}
+
+type restComment struct {
+	ID                int64  `json:"id"`
+	Body              string `json:"body"`
+	AuthorAssociation string `json:"author_association"`
+	CreatedAt         string `json:"created_at"`
+	UpdatedAt         string `json:"updated_at"`
+	HTMLURL           string `json:"html_url"`
+	Path              string `json:"path"`
+	Line              *int   `json:"line"`
+	User              struct {
+		Login string `json:"login"`
+		ID    int64  `json:"id"`
+	} `json:"user"`
+}
+
+func clampIDsPerPage(value int) int {
+	switch {
+	case value <= 0:
+		return 100
+	case value > 100:
+		return 100
+	default:
+		return value
+	}
+}

--- a/internal/comments/service_test.go
+++ b/internal/comments/service_test.go
@@ -119,6 +119,96 @@ func TestServiceList_LatestReviewNotFound(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestServiceIDs_WithLimitAndPagination(t *testing.T) {
+	api := &fakeAPI{}
+	api.restFunc = func(method, path string, params map[string]string, body interface{}, result interface{}) error {
+		switch path {
+		case "repos/octo/demo/pulls/7/reviews/55/comments":
+			require.Equal(t, "50", params["per_page"])
+			require.Equal(t, "2", params["page"])
+			payload := []map[string]interface{}{
+				{
+					"id":                 201,
+					"body":               "hello",
+					"author_association": "MEMBER",
+					"created_at":         "2024-01-01T00:00:00Z",
+					"updated_at":         "2024-01-02T00:00:00Z",
+					"html_url":           "https://example.com",
+					"path":               "file.go",
+					"line":               42,
+					"user": map[string]interface{}{
+						"login": "octocat",
+						"id":    77,
+					},
+				},
+			}
+			return assign(result, payload)
+		default:
+			return errors.New("unexpected path: " + path)
+		}
+	}
+
+	svc := NewService(api)
+	pr := resolver.Identity{Owner: "octo", Repo: "demo", Number: 7, Host: "github.com"}
+	entries, err := svc.IDs(pr, IDsOptions{ReviewID: 55, Limit: 1, PerPage: 50, Page: 2})
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	entry := entries[0]
+	assert.Equal(t, int64(201), entry.ID)
+	assert.Equal(t, "hello", entry.Body)
+	require.NotNil(t, entry.User)
+	assert.Equal(t, "octocat", entry.User.Login)
+	assert.Equal(t, int64(77), entry.User.ID)
+	assert.Equal(t, "MEMBER", entry.AuthorAssociation)
+	assert.Equal(t, "2024-01-01T00:00:00Z", entry.CreatedAt)
+	assert.Equal(t, "2024-01-02T00:00:00Z", entry.UpdatedAt)
+	assert.Equal(t, "https://example.com", entry.HTMLURL)
+	assert.Equal(t, "file.go", entry.Path)
+	require.NotNil(t, entry.Line)
+	assert.Equal(t, 42, *entry.Line)
+}
+
+func TestServiceIDs_WithLatestResolution(t *testing.T) {
+	api := &fakeAPI{}
+	api.restFunc = func(method, path string, params map[string]string, body interface{}, result interface{}) error {
+		switch path {
+		case "user":
+			return assign(result, map[string]interface{}{"login": "octocat"})
+		case "repos/octo/demo/pulls/7/reviews":
+			payload := []map[string]interface{}{
+				{
+					"id":           88,
+					"state":        "COMMENTED",
+					"submitted_at": "2024-02-01T00:00:00Z",
+					"user":         map[string]interface{}{"login": "octocat"},
+				},
+			}
+			return assign(result, payload)
+		case "repos/octo/demo/pulls/7/reviews/88/comments":
+			require.Equal(t, "100", params["per_page"])
+			return assign(result, []map[string]interface{}{{"id": 301, "body": "note"}})
+		default:
+			return errors.New("unexpected path")
+		}
+	}
+
+	svc := NewService(api)
+	pr := resolver.Identity{Owner: "octo", Repo: "demo", Number: 7, Host: "github.com"}
+	entries, err := svc.IDs(pr, IDsOptions{Latest: true})
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, int64(301), entries[0].ID)
+	assert.Equal(t, "note", entries[0].Body)
+}
+
+func TestServiceIDs_InvalidLimit(t *testing.T) {
+	svc := NewService(&fakeAPI{})
+	pr := resolver.Identity{Owner: "octo", Repo: "demo", Number: 7, Host: "github.com"}
+	_, err := svc.IDs(pr, IDsOptions{ReviewID: 55, Limit: -1})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "limit")
+}
+
 func TestServiceReply_AutoSubmitPending(t *testing.T) {
 	api := &fakeAPI{}
 	var submitted []int64

--- a/internal/ghcli/ghcli.go
+++ b/internal/ghcli/ghcli.go
@@ -91,6 +91,7 @@ func (c *Client) REST(method, path string, params map[string]string, body interf
 		args = append(args, "--hostname", host)
 	}
 
+	args = append(args, "--header", "X-GitHub-Api-Version: 2022-11-28")
 	args = append(args, path, "-X", method)
 
 	for key, value := range params {

--- a/internal/review/latest.go
+++ b/internal/review/latest.go
@@ -1,0 +1,147 @@
+package review
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Agyn-sandbox/gh-pr-review/internal/resolver"
+)
+
+// LatestOptions configures lookup of the latest submitted review for a reviewer.
+type LatestOptions struct {
+	Reviewer string
+	PerPage  int
+	Page     int
+}
+
+// ReviewSummary captures a subset of review metadata returned to callers.
+type ReviewSummary struct {
+	ID                int64       `json:"id"`
+	User              *ReviewUser `json:"user,omitempty"`
+	SubmittedAt       *string     `json:"submitted_at,omitempty"`
+	State             string      `json:"state,omitempty"`
+	AuthorAssociation string      `json:"author_association,omitempty"`
+	HTMLURL           string      `json:"html_url,omitempty"`
+}
+
+// ReviewUser mirrors the minimal REST user schema exposed in summaries.
+type ReviewUser struct {
+	Login string `json:"login,omitempty"`
+	ID    int64  `json:"id,omitempty"`
+}
+
+// LatestSubmitted locates the most recent submitted review for the requested reviewer.
+func (s *Service) LatestSubmitted(pr resolver.Identity, opts LatestOptions) (*ReviewSummary, error) {
+	reviewer := strings.TrimSpace(opts.Reviewer)
+	if reviewer == "" {
+		login, err := s.currentLogin()
+		if err != nil {
+			return nil, fmt.Errorf("resolve authenticated user: %w", err)
+		}
+		reviewer = login
+	}
+
+	perPage := clampPerPage(opts.PerPage)
+	page := opts.Page
+	if page <= 0 {
+		page = 1
+	}
+
+	var (
+		latest        restReview
+		hasSubmission bool
+	)
+
+	for current := page; ; current++ {
+		var chunk []restReview
+		params := map[string]string{
+			"per_page": strconv.Itoa(perPage),
+			"page":     strconv.Itoa(current),
+		}
+		path := fmt.Sprintf("repos/%s/%s/pulls/%d/reviews", pr.Owner, pr.Repo, pr.Number)
+		if err := s.API.REST("GET", path, params, nil, &chunk); err != nil {
+			return nil, err
+		}
+
+		if len(chunk) == 0 {
+			break
+		}
+
+		for _, review := range chunk {
+			if !strings.EqualFold(review.User.Login, reviewer) {
+				continue
+			}
+			if review.SubmittedAt == nil {
+				continue
+			}
+			if !hasSubmission || review.SubmittedAt.After(*latest.SubmittedAt) || (review.SubmittedAt.Equal(*latest.SubmittedAt) && review.ID > latest.ID) {
+				latest = review
+				hasSubmission = true
+			}
+		}
+
+		if len(chunk) < perPage {
+			break
+		}
+	}
+
+	if !hasSubmission {
+		return nil, fmt.Errorf("no submitted reviews for %s", reviewer)
+	}
+
+	result := ReviewSummary{
+		ID:                latest.ID,
+		State:             latest.State,
+		AuthorAssociation: strings.TrimSpace(latest.AuthorAssociation),
+		HTMLURL:           strings.TrimSpace(latest.HTMLURL),
+	}
+	if latest.SubmittedAt != nil {
+		ts := latest.SubmittedAt.UTC().Format(time.RFC3339)
+		result.SubmittedAt = &ts
+	}
+	login := strings.TrimSpace(latest.User.Login)
+	if login != "" || latest.User.ID != 0 {
+		result.User = &ReviewUser{Login: login, ID: latest.User.ID}
+	}
+	return &result, nil
+}
+
+type restReview struct {
+	ID                int64      `json:"id"`
+	State             string     `json:"state"`
+	SubmittedAt       *time.Time `json:"submitted_at"`
+	AuthorAssociation string     `json:"author_association"`
+	HTMLURL           string     `json:"html_url"`
+	User              struct {
+		Login string `json:"login"`
+		ID    int64  `json:"id"`
+	} `json:"user"`
+}
+
+func clampPerPage(value int) int {
+	switch {
+	case value <= 0:
+		return 100
+	case value > 100:
+		return 100
+	default:
+		return value
+	}
+}
+
+func (s *Service) currentLogin() (string, error) {
+	var user struct {
+		Login string `json:"login"`
+	}
+	if err := s.API.REST("GET", "user", nil, nil, &user); err != nil {
+		return "", err
+	}
+	login := strings.TrimSpace(user.Login)
+	if login == "" {
+		return "", errors.New("unable to determine authenticated user")
+	}
+	return login, nil
+}

--- a/internal/review/latest_test.go
+++ b/internal/review/latest_test.go
@@ -1,0 +1,126 @@
+package review
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Agyn-sandbox/gh-pr-review/internal/resolver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLatestSubmittedDefaultsToAuthenticatedReviewer(t *testing.T) {
+	api := &fakeAPI{}
+	api.restFunc = func(method, path string, params map[string]string, body interface{}, result interface{}) error {
+		switch path {
+		case "user":
+			payload := map[string]interface{}{"login": "casey"}
+			return assign(result, payload)
+		case "repos/octo/demo/pulls/7/reviews":
+			page := params["page"]
+			perPage := params["per_page"]
+			require.Equal(t, "100", perPage)
+			switch page {
+			case "1":
+				payload := make([]map[string]interface{}, 100)
+				for i := range payload {
+					payload[i] = map[string]interface{}{
+						"id":           i + 1,
+						"state":        "COMMENTED",
+						"submitted_at": "2024-05-01T12:00:00Z",
+						"user":         map[string]interface{}{"login": "other"},
+					}
+				}
+				return assign(result, payload)
+			case "2":
+				payload := []map[string]interface{}{
+					{
+						"id":                 200,
+						"state":              "COMMENTED",
+						"submitted_at":       "2024-06-10T08:00:00Z",
+						"author_association": "MEMBER",
+						"html_url":           "https://github.com/octo/demo/pull/7#review-200",
+						"user": map[string]interface{}{
+							"login": "casey",
+							"id":    101,
+						},
+					},
+				}
+				return assign(result, payload)
+			default:
+				return assign(result, []map[string]interface{}{})
+			}
+		default:
+			return errors.New("unexpected path")
+		}
+	}
+
+	svc := NewService(api)
+	pr := resolver.Identity{Owner: "octo", Repo: "demo", Number: 7, Host: "github.com"}
+	summary, err := svc.LatestSubmitted(pr, LatestOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.Equal(t, int64(200), summary.ID)
+	assert.Equal(t, "COMMENTED", summary.State)
+	require.NotNil(t, summary.SubmittedAt)
+	parsed, parseErr := time.Parse(time.RFC3339, *summary.SubmittedAt)
+	require.NoError(t, parseErr)
+	assert.Equal(t, time.Date(2024, 6, 10, 8, 0, 0, 0, time.UTC), parsed)
+	require.NotNil(t, summary.User)
+	assert.Equal(t, "casey", summary.User.Login)
+	assert.Equal(t, int64(101), summary.User.ID)
+	assert.Equal(t, "https://github.com/octo/demo/pull/7#review-200", summary.HTMLURL)
+	assert.Equal(t, "MEMBER", summary.AuthorAssociation)
+}
+
+func TestLatestSubmittedWithReviewerOverride(t *testing.T) {
+	api := &fakeAPI{}
+	api.restFunc = func(method, path string, params map[string]string, body interface{}, result interface{}) error {
+		if path != "repos/octo/demo/pulls/7/reviews" {
+			return errors.New("unexpected path")
+		}
+		payload := []map[string]interface{}{
+			{
+				"id":           20,
+				"state":        "APPROVED",
+				"submitted_at": "2024-07-01T09:30:00Z",
+				"user": map[string]interface{}{
+					"login": "octocat",
+					"id":    202,
+				},
+			},
+		}
+		return assign(result, payload)
+	}
+
+	svc := NewService(api)
+	pr := resolver.Identity{Owner: "octo", Repo: "demo", Number: 7, Host: "github.com"}
+	summary, err := svc.LatestSubmitted(pr, LatestOptions{Reviewer: "octocat", PerPage: 50, Page: 1})
+	require.NoError(t, err)
+	assert.Equal(t, int64(20), summary.ID)
+	require.NotNil(t, summary.User)
+	assert.Equal(t, "octocat", summary.User.Login)
+	assert.Equal(t, int64(202), summary.User.ID)
+}
+
+func TestLatestSubmittedNoMatches(t *testing.T) {
+	api := &fakeAPI{}
+	api.restFunc = func(method, path string, params map[string]string, body interface{}, result interface{}) error {
+		if path == "user" {
+			payload := map[string]interface{}{"login": "casey"}
+			return assign(result, payload)
+		}
+		if path == "repos/octo/demo/pulls/7/reviews" {
+			return assign(result, []map[string]interface{}{})
+		}
+		return fmt.Errorf("unexpected path %s", path)
+	}
+
+	svc := NewService(api)
+	pr := resolver.Identity{Owner: "octo", Repo: "demo", Number: 7, Host: "github.com"}
+	_, err := svc.LatestSubmitted(pr, LatestOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no submitted reviews")
+}


### PR DESCRIPTION
## Summary
- add JSON-only helper commands for review IDs, comment IDs, and thread resolution
- extend internal services for REST pagination, GHES fallbacks, and API version headers
- document new workflows and cover functionality with unit + smoke tests

## Testing
- CGO_ENABLED=0 go test ./...
- CGO_ENABLED=0 golangci-lint run
- CGO_ENABLED=0 go run . review latest-id -R agyn-sandbox/gh-pr-review-e2e-20251202 --pr 4 --per_page 100 --reviewer emerson-gray
- CGO_ENABLED=0 go run . comments ids agyn-sandbox/gh-pr-review-e2e-20251202#4 --review_id 3531807471 --limit 2 --per_page 50
- CGO_ENABLED=0 go run . threads find -R agyn-sandbox/gh-pr-review-e2e-20251202 --pr 4 --comment_id 2582545223

Resolves #7
