### PR TITLE
Remove JSON flags from thread commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,15 +66,14 @@ gh pr-review review --submit \
 
 ### Manage review threads
 
-List threads and filter by resolution state or participation. The command
-requires `--json` to output structured data:
+List threads and filter by resolution state or participation. Output is always JSON:
 
 ```sh
 # List unresolved threads you can resolve or participated in
-gh pr-review threads list --json --unresolved --mine owner/repo#42
+gh pr-review threads list --unresolved --mine owner/repo#42
 
 # Include all review threads for a pull request URL
-gh pr-review threads list --json https://github.com/owner/repo/pull/42
+gh pr-review threads list https://github.com/owner/repo/pull/42
 ```
 
 Resolve or unresolve threads using either the thread node ID or a REST
@@ -82,13 +81,13 @@ comment identifier:
 
 ```sh
 # Resolve by thread node ID
-gh pr-review threads resolve --json --thread-id R_ywDoABC123 owner/repo#42
+gh pr-review threads resolve --thread-id R_ywDoABC123 owner/repo#42
 
 # Resolve by comment identifier (maps to thread automatically)
-gh pr-review threads resolve --json --comment-id 987654 owner/repo#42
+gh pr-review threads resolve --comment-id 987654 owner/repo#42
 
 # Reopen a thread
-gh pr-review threads unresolve --json --thread-id R_ywDoABC123 owner/repo#42
+gh pr-review threads unresolve --thread-id R_ywDoABC123 owner/repo#42
 ```
 
 All commands accept `-R owner/repo`, pull request URLs, or the `owner/repo#123`

--- a/cmd/threads.go
+++ b/cmd/threads.go
@@ -36,16 +36,12 @@ func newThreadsListCommand() *cobra.Command {
 			if len(args) > 0 {
 				opts.Selector = args[0]
 			}
-			if !opts.JSON {
-				return errors.New("specify --json to select JSON output")
-			}
 			return runThreadsList(cmd, opts)
 		},
 	}
 
 	cmd.Flags().BoolVar(&opts.UnresolvedOnly, "unresolved", false, "Filter to unresolved threads only")
 	cmd.Flags().BoolVar(&opts.MineOnly, "mine", false, "Show only threads involving or resolvable by the viewer")
-	cmd.Flags().BoolVar(&opts.JSON, "json", false, "Emit machine-readable JSON output")
 	cmd.PersistentFlags().StringVarP(&opts.Repo, "repo", "R", "", "Repository in 'owner/repo' format")
 	cmd.PersistentFlags().IntVar(&opts.Pull, "pr", 0, "Pull request number")
 
@@ -58,7 +54,6 @@ type threadsListOptions struct {
 	Selector       string
 	UnresolvedOnly bool
 	MineOnly       bool
-	JSON           bool
 }
 
 func runThreadsList(cmd *cobra.Command, opts *threadsListOptions) error {
@@ -111,9 +106,6 @@ func newThreadsMutationCommand(resolve bool) *cobra.Command {
 			if len(args) > 0 {
 				opts.Selector = args[0]
 			}
-			if !opts.JSON {
-				return errors.New("specify --json to select JSON output")
-			}
 			if err := opts.Validate(); err != nil {
 				return err
 			}
@@ -126,7 +118,6 @@ func newThreadsMutationCommand(resolve bool) *cobra.Command {
 
 	cmd.Flags().StringVar(&opts.ThreadID, "thread-id", "", "GraphQL node ID for the review thread")
 	cmd.Flags().Int64Var(&opts.CommentID, "comment-id", 0, "Pull request review comment identifier")
-	cmd.Flags().BoolVar(&opts.JSON, "json", false, "Emit machine-readable JSON output")
 	cmd.PersistentFlags().StringVarP(&opts.Repo, "repo", "R", "", "Repository in 'owner/repo' format")
 	cmd.PersistentFlags().IntVar(&opts.Pull, "pr", 0, "Pull request number")
 
@@ -139,7 +130,6 @@ type threadsMutationOptions struct {
 	Selector  string
 	ThreadID  string
 	CommentID int64
-	JSON      bool
 }
 
 func (o *threadsMutationOptions) Validate() error {

--- a/cmd/threads_test.go
+++ b/cmd/threads_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestThreadsListCommandJSON(t *testing.T) {
+func TestThreadsListCommandOutputsJSON(t *testing.T) {
 	originalFactory := apiClientFactory
 	defer func() { apiClientFactory = originalFactory }()
 
@@ -87,7 +87,7 @@ func TestThreadsListCommandJSON(t *testing.T) {
 	stderr := &bytes.Buffer{}
 	root.SetOut(stdout)
 	root.SetErr(stderr)
-	root.SetArgs([]string{"threads", "list", "--json", "--unresolved", "--mine", "octo/demo#5"})
+	root.SetArgs([]string{"threads", "list", "--unresolved", "--mine", "octo/demo#5"})
 
 	err := root.Execute()
 	require.NoError(t, err)
@@ -161,7 +161,7 @@ func TestThreadsResolveCommandByCommentID(t *testing.T) {
 	stderr := &bytes.Buffer{}
 	root.SetOut(stdout)
 	root.SetErr(stderr)
-	root.SetArgs([]string{"threads", "resolve", "--json", "--comment-id", "88", "octo/demo#9"})
+	root.SetArgs([]string{"threads", "resolve", "--comment-id", "88", "octo/demo#9"})
 
 	err := root.Execute()
 	require.NoError(t, err)
@@ -225,7 +225,7 @@ func TestThreadsUnresolveCommandByThreadID(t *testing.T) {
 	stderr := &bytes.Buffer{}
 	root.SetOut(stdout)
 	root.SetErr(stderr)
-	root.SetArgs([]string{"threads", "unresolve", "--json", "--thread-id", "T_thread", "octo/demo#9"})
+	root.SetArgs([]string{"threads", "unresolve", "--thread-id", "T_thread", "octo/demo#9"})
 
 	err := root.Execute()
 	require.NoError(t, err)
@@ -291,7 +291,7 @@ func TestThreadsUnresolveRequiresIdentifier(t *testing.T) {
 	root := newRootCommand()
 	root.SetOut(&bytes.Buffer{})
 	root.SetErr(&bytes.Buffer{})
-	root.SetArgs([]string{"threads", "unresolve", "--json", "octo/demo#2"})
+	root.SetArgs([]string{"threads", "unresolve", "octo/demo#2"})
 
 	err := root.Execute()
 	require.Error(t, err)
@@ -302,20 +302,9 @@ func TestThreadsResolveRequiresExclusiveSelector(t *testing.T) {
 	root := newRootCommand()
 	root.SetOut(&bytes.Buffer{})
 	root.SetErr(&bytes.Buffer{})
-	root.SetArgs([]string{"threads", "resolve", "--json", "--thread-id", "T1", "--comment-id", "2", "octo/demo#1"})
+	root.SetArgs([]string{"threads", "resolve", "--thread-id", "T1", "--comment-id", "2", "octo/demo#1"})
 
 	err := root.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "either --thread-id or --comment-id")
-}
-
-func TestThreadsListRequiresJSONFlag(t *testing.T) {
-	root := newRootCommand()
-	root.SetOut(&bytes.Buffer{})
-	root.SetErr(&bytes.Buffer{})
-	root.SetArgs([]string{"threads", "list", "octo/demo#5"})
-
-	err := root.Execute()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "--json")
 }


### PR DESCRIPTION
## Summary
- remove the `--json` flag from threads list/resolve/unresolve so ID helpers emit JSON by default
- adjust CLI validation and tests to reflect implicit JSON output
- refresh README examples to demonstrate JSON defaults

## Testing
- CGO_ENABLED=0 go test ./...
- CGO_ENABLED=0 golangci-lint run
- CGO_ENABLED=0 go run . review latest-id -R agyn-sandbox/gh-pr-review-e2e-20251202 --pr 4 --per_page 100 --reviewer emerson-gray
- CGO_ENABLED=0 go run . comments ids agyn-sandbox/gh-pr-review-e2e-20251202#4 --review_id 3531807471 --limit 2 --per_page 50
- CGO_ENABLED=0 go run . threads find -R agyn-sandbox/gh-pr-review-e2e-20251202 --pr 4 --comment_id 2582545223
- CGO_ENABLED=0 go run . threads list -R agyn-sandbox/gh-pr-review-e2e-20251202 --pr 4 --unresolved

Resolves #7
