### PR TITLE
feat: add pending review id lookup

### DIFF
--- a/internal/review/pending.go
+++ b/internal/review/pending.go
@@ -1,0 +1,89 @@
+package review
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/Agyn-sandbox/gh-pr-review/internal/resolver"
+)
+
+// PendingOptions configures lookup of the latest pending review for a reviewer.
+type PendingOptions struct {
+	Reviewer string
+	PerPage  int
+	Page     int
+}
+
+// LatestPending locates the most recent pending review for the requested reviewer.
+func (s *Service) LatestPending(pr resolver.Identity, opts PendingOptions) (*ReviewSummary, error) {
+	reviewer := strings.TrimSpace(opts.Reviewer)
+	if reviewer == "" {
+		login, err := s.currentLogin()
+		if err != nil {
+			return nil, fmt.Errorf("resolve authenticated user: %w", err)
+		}
+		reviewer = login
+	}
+
+	perPage := clampPerPage(opts.PerPage)
+	page := opts.Page
+	if page <= 0 {
+		page = 1
+	}
+
+	var (
+		latestPending restReview
+		found         bool
+	)
+
+	for current := page; ; current++ {
+		var chunk []restReview
+		params := map[string]string{
+			"per_page": strconv.Itoa(perPage),
+			"page":     strconv.Itoa(current),
+		}
+		path := fmt.Sprintf("repos/%s/%s/pulls/%d/reviews", pr.Owner, pr.Repo, pr.Number)
+		if err := s.API.REST("GET", path, params, nil, &chunk); err != nil {
+			return nil, err
+		}
+
+		if len(chunk) == 0 {
+			break
+		}
+
+		for _, review := range chunk {
+			if !strings.EqualFold(review.User.Login, reviewer) {
+				continue
+			}
+			if !strings.EqualFold(strings.TrimSpace(review.State), "PENDING") {
+				continue
+			}
+			if !found || review.ID > latestPending.ID {
+				latestPending = review
+				found = true
+			}
+		}
+
+		if len(chunk) < perPage {
+			break
+		}
+	}
+
+	if !found {
+		return nil, fmt.Errorf("no pending reviews for %s", reviewer)
+	}
+
+	summary := ReviewSummary{
+		ID:                latestPending.ID,
+		State:             strings.ToUpper(strings.TrimSpace(latestPending.State)),
+		AuthorAssociation: strings.TrimSpace(latestPending.AuthorAssociation),
+		HTMLURL:           strings.TrimSpace(latestPending.HTMLURL),
+	}
+	login := strings.TrimSpace(latestPending.User.Login)
+	if login != "" || latestPending.User.ID != 0 {
+		summary.User = &ReviewUser{Login: login, ID: latestPending.User.ID}
+	}
+
+	return &summary, nil
+}

--- a/internal/review/pending_test.go
+++ b/internal/review/pending_test.go
@@ -1,0 +1,126 @@
+package review
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/Agyn-sandbox/gh-pr-review/internal/resolver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLatestPendingDefaultsToAuthenticatedReviewer(t *testing.T) {
+	api := &fakeAPI{}
+	api.restFunc = func(method, path string, params map[string]string, body interface{}, result interface{}) error {
+		switch path {
+		case "user":
+			return assign(result, map[string]interface{}{"login": "casey"})
+		case "repos/octo/demo/pulls/7/reviews":
+			require.Equal(t, "100", params["per_page"])
+			switch params["page"] {
+			case "1":
+				payload := []map[string]interface{}{
+					{
+						"id":                 5,
+						"state":              "PENDING",
+						"author_association": "MEMBER",
+						"html_url":           "https://github.com/octo/demo/pull/7#review-5",
+						"user": map[string]interface{}{
+							"login": "casey",
+							"id":    101,
+						},
+					},
+					{
+						"id":                 7,
+						"state":              "PENDING",
+						"author_association": "MEMBER",
+						"html_url":           "https://github.com/octo/demo/pull/7#review-7",
+						"user": map[string]interface{}{
+							"login": "casey",
+							"id":    101,
+						},
+					},
+					{
+						"id":    9,
+						"state": "PENDING",
+						"user":  map[string]interface{}{"login": "other"},
+					},
+				}
+				return assign(result, payload)
+			default:
+				return assign(result, []map[string]interface{}{})
+			}
+		default:
+			return errors.New("unexpected path")
+		}
+	}
+
+	svc := NewService(api)
+	pr := resolver.Identity{Owner: "octo", Repo: "demo", Number: 7, Host: "github.com"}
+	summary, err := svc.LatestPending(pr, PendingOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.Equal(t, int64(7), summary.ID)
+	assert.Equal(t, "PENDING", summary.State)
+	require.NotNil(t, summary.User)
+	assert.Equal(t, "casey", summary.User.Login)
+	assert.Equal(t, int64(101), summary.User.ID)
+	assert.Equal(t, "https://github.com/octo/demo/pull/7#review-7", summary.HTMLURL)
+	assert.Equal(t, "MEMBER", summary.AuthorAssociation)
+}
+
+func TestLatestPendingWithReviewerOverride(t *testing.T) {
+	api := &fakeAPI{}
+	api.restFunc = func(method, path string, params map[string]string, body interface{}, result interface{}) error {
+		if path != "repos/octo/demo/pulls/7/reviews" {
+			return errors.New("unexpected path")
+		}
+		require.Equal(t, "50", params["per_page"])
+		require.Equal(t, "3", params["page"])
+		payload := []map[string]interface{}{
+			{
+				"id":                 42,
+				"state":              "PENDING",
+				"author_association": "CONTRIBUTOR",
+				"html_url":           "https://example.com/review/42",
+				"user": map[string]interface{}{
+					"login": "octocat",
+					"id":    202,
+				},
+			},
+		}
+		return assign(result, payload)
+	}
+
+	svc := NewService(api)
+	pr := resolver.Identity{Owner: "octo", Repo: "demo", Number: 7, Host: "github.com"}
+	summary, err := svc.LatestPending(pr, PendingOptions{Reviewer: "octocat", PerPage: 50, Page: 3})
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.Equal(t, int64(42), summary.ID)
+	require.NotNil(t, summary.User)
+	assert.Equal(t, "octocat", summary.User.Login)
+	assert.Equal(t, int64(202), summary.User.ID)
+	assert.Equal(t, "https://example.com/review/42", summary.HTMLURL)
+}
+
+func TestLatestPendingNoMatches(t *testing.T) {
+	api := &fakeAPI{}
+	api.restFunc = func(method, path string, params map[string]string, body interface{}, result interface{}) error {
+		switch path {
+		case "user":
+			return assign(result, map[string]interface{}{"login": "casey"})
+		case "repos/octo/demo/pulls/7/reviews":
+			return assign(result, []map[string]interface{}{})
+		default:
+			return fmt.Errorf("unexpected path %s", path)
+		}
+	}
+
+	svc := NewService(api)
+	pr := resolver.Identity{Owner: "octo", Repo: "demo", Number: 7, Host: "github.com"}
+	_, err := svc.LatestPending(pr, PendingOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no pending reviews")
+}


### PR DESCRIPTION
Resolves #16.

## Summary
- add `review pending-id` subcommand wired into the CLI
- implement REST-driven pending review lookup with tests
- cover the new command with CLI and service unit tests

## Usage
```
gh pr-review review pending-id --reviewer octocat owner/repo#42
```

## JSON Output
```
{
  "id": 3531807471,
  "state": "PENDING",
  "author_association": "MEMBER",
  "html_url": "https://github.com/owner/repo/pull/42#review-3531807471",
  "user": {
    "login": "octocat",
    "id": 123456
  }
}
```

## Testing
- CGO_ENABLED=0 go test ./...
- CGO_ENABLED=0 golangci-lint run
