### PR TITLE
feat: enrich review output metadata

### DIFF
--- a/cmd/review_test.go
+++ b/cmd/review_test.go
@@ -27,7 +27,12 @@ func TestReviewStartCommand(t *testing.T) {
 		payload := map[string]interface{}{
 			"data": map[string]interface{}{
 				"addPullRequestReview": map[string]interface{}{
-					"pullRequestReview": map[string]interface{}{"id": "RV1", "state": "PENDING"},
+					"pullRequestReview": map[string]interface{}{
+						"id":         "RV1",
+						"state":      "PENDING",
+						"databaseId": 88,
+						"url":        "https://example.com/review/RV1",
+					},
 				},
 			},
 		}
@@ -49,6 +54,8 @@ func TestReviewStartCommand(t *testing.T) {
 	var payload map[string]interface{}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &payload))
 	assert.Equal(t, "RV1", payload["id"])
+	assert.Equal(t, float64(88), payload["database_id"])
+	assert.Equal(t, "https://example.com/review/RV1", payload["html_url"])
 }
 
 func TestReviewAddCommentCommand(t *testing.T) {
@@ -93,7 +100,12 @@ func TestReviewSubmitCommand(t *testing.T) {
 		payload := map[string]interface{}{
 			"data": map[string]interface{}{
 				"submitPullRequestReview": map[string]interface{}{
-					"pullRequestReview": map[string]interface{}{"id": "RV1", "state": "COMMENTED"},
+					"pullRequestReview": map[string]interface{}{
+						"id":         "RV1",
+						"state":      "COMMENTED",
+						"databaseId": 99,
+						"url":        "https://example.com/review/RV1",
+					},
 				},
 			},
 		}
@@ -115,6 +127,8 @@ func TestReviewSubmitCommand(t *testing.T) {
 	var payload map[string]interface{}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &payload))
 	assert.Equal(t, "RV1", payload["id"])
+	assert.Equal(t, float64(99), payload["database_id"])
+	assert.Equal(t, "https://example.com/review/RV1", payload["html_url"])
 }
 
 func TestReviewLatestIDCommand(t *testing.T) {

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -42,7 +42,13 @@ func TestServiceStart(t *testing.T) {
 		payload := map[string]interface{}{
 			"data": map[string]interface{}{
 				"addPullRequestReview": map[string]interface{}{
-					"pullRequestReview": map[string]interface{}{"id": "RV1", "state": "PENDING", "submittedAt": nil},
+					"pullRequestReview": map[string]interface{}{
+						"id":          "RV1",
+						"state":       "PENDING",
+						"submittedAt": nil,
+						"databaseId":  321,
+						"url":         "https://example.com/review/RV1",
+					},
 				},
 			},
 		}
@@ -55,6 +61,9 @@ func TestServiceStart(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "RV1", state.ID)
 	assert.Equal(t, "PENDING", state.State)
+	require.NotNil(t, state.DatabaseID)
+	assert.Equal(t, int64(321), *state.DatabaseID)
+	assert.Equal(t, "https://example.com/review/RV1", state.HTMLURL)
 }
 
 func TestServiceAddThread(t *testing.T) {
@@ -83,7 +92,13 @@ func TestServiceSubmit(t *testing.T) {
 		payload := map[string]interface{}{
 			"data": map[string]interface{}{
 				"submitPullRequestReview": map[string]interface{}{
-					"pullRequestReview": map[string]interface{}{"id": "RV1", "state": "COMMENTED", "submittedAt": "2024-05-01T12:00:00Z"},
+					"pullRequestReview": map[string]interface{}{
+						"id":          "RV1",
+						"state":       "COMMENTED",
+						"submittedAt": "2024-05-01T12:00:00Z",
+						"databaseId":  654,
+						"url":         "https://example.com/review/RV1",
+					},
 				},
 			},
 		}
@@ -96,6 +111,9 @@ func TestServiceSubmit(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "RV1", state.ID)
 	assert.Equal(t, "COMMENTED", state.State)
+	require.NotNil(t, state.DatabaseID)
+	assert.Equal(t, int64(654), *state.DatabaseID)
+	assert.Equal(t, "https://example.com/review/RV1", state.HTMLURL)
 }
 
 func assign(result interface{}, payload interface{}) error {


### PR DESCRIPTION
Resolves #17.

## Summary
- extend GraphQL selections for review start/submit to include databaseId and url
- surface database_id and html_url fields in the review state JSON schema
- add unit coverage for enriched metadata across service and CLI paths

## Example Output
```
{
  "id": "RV_kwDO...",
  "state": "PENDING",
  "submitted_at": null,
  "database_id": 3531807471,
  "html_url": "https://github.com/owner/repo/pull/42#review-3531807471"
}
```

## Testing
- CGO_ENABLED=0 go test ./...
- CGO_ENABLED=0 golangci-lint run
