### PR TITLE
docs: clarify json output conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,15 @@ Outputs are pure JSON with REST/GraphQL field names and include only fields that
 are present from the source APIs (no null placeholders). The `threads find`
 command always emits exactly `{ "id", "isResolved" }`.
 
+## Output conventions
+
+All commands emit JSON aligned with GitHub REST/GraphQL schemas.
+
+- Arrays are serialized as `[]` when no results are available.
+- No plaintext is printed; even errors bubble up through the CLI.
+- `gh pr-review comments reply --concise` trims the payload to `{ "id" }` while
+  the default mode returns the full REST response.
+
 ## Agent usage guide
 
 See [docs/AGENTS.md](docs/AGENTS.md) for agent-focused workflows, prompts, and

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -3,6 +3,9 @@
 This guide provides ready-to-run prompts for scripted or agent-driven use of
 `gh pr-review`. All commands emit JSON with REST/GraphQL-aligned field names and
 include only values present in upstream responses (no null placeholders).
+Empty collections are emitted as `[]` instead of `null`, and the
+`comments reply --concise` mode returns `{ "id" }` when you only need the
+database identifier.
 
 ## 1. Review a pull request end-to-end
 

--- a/internal/comments/service.go
+++ b/internal/comments/service.go
@@ -44,7 +44,7 @@ func (s *Service) List(pr resolver.Identity, opts ListOptions) ([]json.RawMessag
 		return nil, err
 	}
 
-	var all []json.RawMessage
+	all := make([]json.RawMessage, 0)
 	page := 1
 	for {
 		var chunk []json.RawMessage

--- a/internal/comments/service_test.go
+++ b/internal/comments/service_test.go
@@ -119,6 +119,29 @@ func TestServiceList_LatestReviewNotFound(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestServiceList_ReturnsEmptySlice(t *testing.T) {
+	api := &fakeAPI{}
+	api.restFunc = func(method, path string, params map[string]string, body interface{}, result interface{}) error {
+		switch path {
+		case "repos/octo/demo/pulls/7/reviews/55/comments":
+			return assign(result, []map[string]interface{}{})
+		case "repos/octo/demo/pulls/7/reviews":
+			return assign(result, []map[string]interface{}{})
+		case "user":
+			return assign(result, map[string]interface{}{"login": "octocat"})
+		default:
+			return errors.New("unexpected path")
+		}
+	}
+
+	svc := NewService(api)
+	pr := resolver.Identity{Owner: "octo", Repo: "demo", Number: 7, Host: "github.com"}
+	comments, err := svc.List(pr, ListOptions{ReviewID: 55})
+	require.NoError(t, err)
+	require.NotNil(t, comments)
+	assert.Empty(t, comments)
+}
+
 func TestServiceIDs_WithLimitAndPagination(t *testing.T) {
 	api := &fakeAPI{}
 	api.restFunc = func(method, path string, params map[string]string, body interface{}, result interface{}) error {


### PR DESCRIPTION
Resolves #21.

## Summary
- add a README section describing JSON output conventions
- expand the agent guide with concise reply and empty array notes
- normalize remaining list helpers to emit `[]` when empty with regression tests

## Example Output
```
[]
```

## Testing
- CGO_ENABLED=0 go test ./...
- CGO_ENABLED=0 golangci-lint run
