### PR TITLE
Add Agyn badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # gh-pr-review
+[![Agyn badge](https://agyn.io/badges/badge_dark.svg)](http://agyn.io)
 
 `gh-pr-review` is a precompiled GitHub CLI extension that streamlines
 pull request review workflows. It adds helpers for listing review comments,


### PR DESCRIPTION
## Summary
- add the Agyn badge directly beneath the README heading
- verified the badge renders and links correctly via local pandoc preview

## Testing
- CGO_ENABLED=0 go test ./...
- CGO_ENABLED=0 go vet ./...

```markdown
[![Agyn badge](https://agyn.io/badges/badge_dark.svg)](http://agyn.io)
```

Resolves #28
