### PR TITLE
fix: enrich pending review identifiers

### DIFF
--- a/cmd/review_test.go
+++ b/cmd/review_test.go
@@ -101,10 +101,11 @@ func TestReviewSubmitCommand(t *testing.T) {
 			"data": map[string]interface{}{
 				"submitPullRequestReview": map[string]interface{}{
 					"pullRequestReview": map[string]interface{}{
-						"id":         "RV1",
-						"state":      "COMMENTED",
-						"databaseId": 99,
-						"url":        "https://example.com/review/RV1",
+						"id":          "RV1",
+						"state":       "COMMENTED",
+						"submittedAt": "2024-05-01T12:00:00Z",
+						"databaseId":  99,
+						"url":         "https://example.com/review/RV1",
 					},
 				},
 			},
@@ -127,6 +128,8 @@ func TestReviewSubmitCommand(t *testing.T) {
 	var payload map[string]interface{}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &payload))
 	assert.Equal(t, "RV1", payload["id"])
+	assert.Equal(t, "COMMENTED", payload["state"])
+	assert.Equal(t, "2024-05-01T12:00:00Z", payload["submitted_at"])
 	assert.Equal(t, float64(99), payload["database_id"])
 	assert.Equal(t, "https://example.com/review/RV1", payload["html_url"])
 }
@@ -197,6 +200,7 @@ func TestReviewPendingIDCommand(t *testing.T) {
 			payload := []map[string]interface{}{
 				{
 					"id":                 15,
+					"node_id":            "R_pending_15",
 					"state":              "PENDING",
 					"author_association": "MEMBER",
 					"html_url":           "https://example.com/pending",
@@ -223,7 +227,8 @@ func TestReviewPendingIDCommand(t *testing.T) {
 
 	var payload map[string]interface{}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &payload))
-	assert.Equal(t, float64(15), payload["id"])
+	assert.Equal(t, "R_pending_15", payload["id"])
+	assert.Equal(t, float64(15), payload["database_id"])
 	assert.Equal(t, "PENDING", payload["state"])
 	assert.Equal(t, "https://example.com/pending", payload["html_url"])
 

--- a/internal/review/latest.go
+++ b/internal/review/latest.go
@@ -111,6 +111,7 @@ func (s *Service) LatestSubmitted(pr resolver.Identity, opts LatestOptions) (*Re
 
 type restReview struct {
 	ID                int64      `json:"id"`
+	NodeID            string     `json:"node_id"`
 	State             string     `json:"state"`
 	SubmittedAt       *time.Time `json:"submitted_at"`
 	AuthorAssociation string     `json:"author_association"`

--- a/internal/review/pending.go
+++ b/internal/review/pending.go
@@ -15,8 +15,18 @@ type PendingOptions struct {
 	Page     int
 }
 
+// PendingSummary captures pending review metadata for output.
+type PendingSummary struct {
+	ID                string      `json:"id"`
+	DatabaseID        int64       `json:"database_id"`
+	State             string      `json:"state"`
+	AuthorAssociation string      `json:"author_association,omitempty"`
+	HTMLURL           string      `json:"html_url,omitempty"`
+	User              *ReviewUser `json:"user,omitempty"`
+}
+
 // LatestPending locates the most recent pending review for the requested reviewer.
-func (s *Service) LatestPending(pr resolver.Identity, opts PendingOptions) (*ReviewSummary, error) {
+func (s *Service) LatestPending(pr resolver.Identity, opts PendingOptions) (*PendingSummary, error) {
 	reviewer := strings.TrimSpace(opts.Reviewer)
 	if reviewer == "" {
 		login, err := s.currentLogin()
@@ -74,8 +84,14 @@ func (s *Service) LatestPending(pr resolver.Identity, opts PendingOptions) (*Rev
 		return nil, fmt.Errorf("no pending reviews for %s", reviewer)
 	}
 
-	summary := ReviewSummary{
-		ID:                latestPending.ID,
+	nodeID := strings.TrimSpace(latestPending.NodeID)
+	if nodeID == "" {
+		return nil, fmt.Errorf("pending review %d missing node identifier", latestPending.ID)
+	}
+
+	summary := PendingSummary{
+		ID:                nodeID,
+		DatabaseID:        latestPending.ID,
 		State:             strings.ToUpper(strings.TrimSpace(latestPending.State)),
 		AuthorAssociation: strings.TrimSpace(latestPending.AuthorAssociation),
 		HTMLURL:           strings.TrimSpace(latestPending.HTMLURL),

--- a/internal/review/pending_test.go
+++ b/internal/review/pending_test.go
@@ -23,6 +23,7 @@ func TestLatestPendingDefaultsToAuthenticatedReviewer(t *testing.T) {
 				payload := []map[string]interface{}{
 					{
 						"id":                 5,
+						"node_id":            "R_pending_5",
 						"state":              "PENDING",
 						"author_association": "MEMBER",
 						"html_url":           "https://github.com/octo/demo/pull/7#review-5",
@@ -33,6 +34,7 @@ func TestLatestPendingDefaultsToAuthenticatedReviewer(t *testing.T) {
 					},
 					{
 						"id":                 7,
+						"node_id":            "R_pending_7",
 						"state":              "PENDING",
 						"author_association": "MEMBER",
 						"html_url":           "https://github.com/octo/demo/pull/7#review-7",
@@ -42,9 +44,10 @@ func TestLatestPendingDefaultsToAuthenticatedReviewer(t *testing.T) {
 						},
 					},
 					{
-						"id":    9,
-						"state": "PENDING",
-						"user":  map[string]interface{}{"login": "other"},
+						"id":      9,
+						"node_id": "R_pending_9",
+						"state":   "PENDING",
+						"user":    map[string]interface{}{"login": "other"},
 					},
 				}
 				return assign(result, payload)
@@ -61,7 +64,8 @@ func TestLatestPendingDefaultsToAuthenticatedReviewer(t *testing.T) {
 	summary, err := svc.LatestPending(pr, PendingOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, summary)
-	assert.Equal(t, int64(7), summary.ID)
+	assert.Equal(t, "R_pending_7", summary.ID)
+	assert.Equal(t, int64(7), summary.DatabaseID)
 	assert.Equal(t, "PENDING", summary.State)
 	require.NotNil(t, summary.User)
 	assert.Equal(t, "casey", summary.User.Login)
@@ -81,6 +85,7 @@ func TestLatestPendingWithReviewerOverride(t *testing.T) {
 		payload := []map[string]interface{}{
 			{
 				"id":                 42,
+				"node_id":            "R_pending_42",
 				"state":              "PENDING",
 				"author_association": "CONTRIBUTOR",
 				"html_url":           "https://example.com/review/42",
@@ -98,7 +103,8 @@ func TestLatestPendingWithReviewerOverride(t *testing.T) {
 	summary, err := svc.LatestPending(pr, PendingOptions{Reviewer: "octocat", PerPage: 50, Page: 3})
 	require.NoError(t, err)
 	require.NotNil(t, summary)
-	assert.Equal(t, int64(42), summary.ID)
+	assert.Equal(t, "R_pending_42", summary.ID)
+	assert.Equal(t, int64(42), summary.DatabaseID)
 	require.NotNil(t, summary.User)
 	assert.Equal(t, "octocat", summary.User.Login)
 	assert.Equal(t, int64(202), summary.User.ID)

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -111,6 +111,8 @@ func TestServiceSubmit(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "RV1", state.ID)
 	assert.Equal(t, "COMMENTED", state.State)
+	require.NotNil(t, state.SubmittedAt)
+	assert.Equal(t, "2024-05-01T12:00:00Z", *state.SubmittedAt)
 	require.NotNil(t, state.DatabaseID)
 	assert.Equal(t, int64(654), *state.DatabaseID)
 	assert.Equal(t, "https://example.com/review/RV1", state.HTMLURL)


### PR DESCRIPTION
Resolves #30.

## Summary
- expose the review GraphQL node id and REST database id in `review pending-id`
- ensure pending summaries still include state, author association, html url, and user metadata
- return enriched fields (`id`, `state`, `submitted_at`, `database_id`, `html_url`) from `review --submit`
- extend service and CLI tests to cover the new response shapes

## Testing
- CGO_ENABLED=0 go test ./...
- CGO_ENABLED=0 golangci-lint run
