### PR TITLE
test(cmd): cover graphql review flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ GitHub Enterprise environments.
 Emit minimal JSON for frequently needed identifiers:
 
 ```sh
+# Locate the latest pending review for a reviewer (GraphQL only)
+gh pr-review review pending-id --per_page 100 --reviewer octocat owner/repo#42
+
 # Locate the latest submitted review for a reviewer
 gh pr-review review latest-id --per_page 100 --page 1 --reviewer octocat owner/repo#42
 
@@ -116,8 +119,10 @@ gh pr-review threads find --comment_id 2582545223 owner/repo#42
 ```
 
 Outputs are pure JSON with REST/GraphQL field names and include only fields that
-are present from the source APIs (no null placeholders). The `threads find`
-command always emits exactly `{ "id", "isResolved" }`.
+are present from the source APIs (no null placeholders). Pending-review helpers
+use GitHub's GraphQL API exclusively and fail fast if required payloads are
+missing. The `threads find` command always emits exactly `{ "id",
+"isResolved" }`.
 
 ## Output conventions
 

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -205,8 +205,7 @@ func newReviewPendingIDCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&opts.Repo, "repo", "R", "", "Repository in 'owner/repo' format")
 	cmd.Flags().IntVar(&opts.Pull, "pr", 0, "Pull request number")
 	cmd.Flags().StringVar(&opts.Reviewer, "reviewer", "", "Reviewer login (defaults to authenticated user)")
-	cmd.Flags().IntVar(&opts.PerPage, "per_page", 0, "Number of reviews per page (REST)")
-	cmd.Flags().IntVar(&opts.Page, "page", 0, "Page index for the initial REST request")
+	cmd.Flags().IntVar(&opts.PerPage, "per_page", 0, "Number of reviews to request from GraphQL (max 100)")
 
 	return cmd
 }
@@ -217,7 +216,6 @@ type reviewPendingOptions struct {
 	Selector string
 	Reviewer string
 	PerPage  int
-	Page     int
 }
 
 func runReviewPendingID(cmd *cobra.Command, opts *reviewPendingOptions) error {
@@ -236,7 +234,6 @@ func runReviewPendingID(cmd *cobra.Command, opts *reviewPendingOptions) error {
 	summary, err := service.LatestPending(identity, reviewsvc.PendingOptions{
 		Reviewer: opts.Reviewer,
 		PerPage:  opts.PerPage,
-		Page:     opts.Page,
 	})
 	if err != nil {
 		return err

--- a/cmd/review_test.go
+++ b/cmd/review_test.go
@@ -343,63 +343,52 @@ func TestReviewPendingIDCommand_GraphQLOnly(t *testing.T) {
 	defer func() { apiClientFactory = originalFactory }()
 
 	fake := &commandFakeAPI{}
-	call := 0
 	fake.graphqlFunc = func(query string, variables map[string]interface{}, result interface{}) error {
-		call++
-		switch call {
-		case 1:
-			payload := obj{
-				"data": obj{
-					"viewer": obj{
-						"login":      "casey",
-						"databaseId": 77,
-					},
+		payload := obj{
+			"data": obj{
+				"viewer": obj{
+					"login":      "casey",
+					"databaseId": 77,
 				},
-			}
-			return assignJSON(result, payload)
-		default:
-			payload := obj{
-				"data": obj{
-					"repository": obj{
-						"pullRequest": obj{
-							"reviews": obj{
-								"nodes": objSlice{
-									obj{
-										"id":         "PRR_node_old",
-										"databaseId": 10,
-										"url":        "https://example.com/review/10",
-										"state":      "PENDING",
-										"author": obj{
-											"login":      "casey",
-											"databaseId": 77,
-										},
-										"updatedAt": "2024-06-01T12:00:00Z",
-										"createdAt": "2024-06-01T11:00:00Z",
+				"repository": obj{
+					"pullRequest": obj{
+						"reviews": obj{
+							"nodes": objSlice{
+								obj{
+									"id":         "PRR_node_old",
+									"databaseId": 10,
+									"url":        "https://example.com/review/10",
+									"state":      "PENDING",
+									"author": obj{
+										"login":      "casey",
+										"databaseId": 77,
 									},
-									obj{
-										"id":         "PRR_node_new",
-										"databaseId": 22,
-										"url":        "https://example.com/review/22",
-										"state":      "PENDING",
-										"author": obj{
-											"login":      "casey",
-											"databaseId": 77,
-										},
-										"updatedAt": "2024-06-01T13:00:00Z",
-										"createdAt": "2024-06-01T12:30:00Z",
+									"updatedAt": "2024-06-01T12:00:00Z",
+									"createdAt": "2024-06-01T11:00:00Z",
+								},
+								obj{
+									"id":         "PRR_node_new",
+									"databaseId": 22,
+									"url":        "https://example.com/review/22",
+									"state":      "PENDING",
+									"author": obj{
+										"login":      "casey",
+										"databaseId": 77,
 									},
+									"updatedAt": "2024-06-01T13:00:00Z",
+									"createdAt": "2024-06-01T12:30:00Z",
 								},
-								"pageInfo": obj{
-									"hasNextPage": false,
-									"endCursor":   "",
-								},
+							},
+							"pageInfo": obj{
+								"hasNextPage": false,
+								"endCursor":   "",
 							},
 						},
 					},
 				},
-			}
-			return assignJSON(result, payload)
+			},
 		}
+		return assignJSON(result, payload)
 	}
 	apiClientFactory = func(host string) ghcli.API { return fake }
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -27,7 +27,13 @@ gh pr-review review --submit \
   --event APPROVE \
   --body "Looks good" \
   owner/repo#42
+
+# Fetch the latest pending review identifier (GraphQL only)
+gh pr-review review pending-id --reviewer octocat owner/repo#42
 ```
+
+> **Note:** Pending-review helpers use GitHub's GraphQL API exclusively. The
+> command fails fast if the GraphQL payload omits the requested review data.
 
 ## 2. Read and reply to inline comments
 

--- a/internal/comments/service_test.go
+++ b/internal/comments/service_test.go
@@ -3,6 +3,7 @@ package comments
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -37,6 +38,20 @@ func assign(result interface{}, payload interface{}) error {
 		return err
 	}
 	return json.Unmarshal(data, result)
+}
+
+type pendingReviewNode struct {
+	ID                string `json:"id"`
+	DatabaseID        int64  `json:"databaseId"`
+	State             string `json:"state"`
+	AuthorAssociation string `json:"authorAssociation"`
+	URL               string `json:"url"`
+	UpdatedAt         string `json:"updatedAt"`
+	CreatedAt         string `json:"createdAt"`
+	Author            struct {
+		Login      string `json:"login"`
+		DatabaseID int64  `json:"databaseId"`
+	} `json:"author"`
 }
 
 func TestServiceList_WithReviewIDPagination(t *testing.T) {
@@ -254,6 +269,59 @@ func TestServiceReply_AutoSubmitPending(t *testing.T) {
 	api := &fakeAPI{}
 	var submitted []int64
 	attempt := 0
+	api.graphqlFunc = func(query string, variables map[string]interface{}, result interface{}) error {
+		if !strings.Contains(query, "PendingReviews") {
+			return errors.New("unexpected query: " + query)
+		}
+		require.Equal(t, "octo", variables["owner"])
+		require.Equal(t, "demo", variables["name"])
+		require.EqualValues(t, 7, variables["number"])
+		require.EqualValues(t, 100, variables["pageSize"])
+		_, hasCursor := variables["cursor"]
+		require.False(t, hasCursor)
+		_, hasAuthor := variables["author"]
+		require.False(t, hasAuthor)
+
+		payload := struct {
+			Data struct {
+				Viewer struct {
+					Login      string `json:"login"`
+					DatabaseID int64  `json:"databaseId"`
+				} `json:"viewer"`
+				Repository struct {
+					PullRequest struct {
+						Reviews struct {
+							Nodes    []pendingReviewNode `json:"nodes"`
+							PageInfo struct {
+								HasNextPage bool   `json:"hasNextPage"`
+								EndCursor   string `json:"endCursor"`
+							} `json:"pageInfo"`
+						} `json:"reviews"`
+					} `json:"pullRequest"`
+				} `json:"repository"`
+			} `json:"data"`
+		}{}
+		payload.Data.Viewer.Login = "casey"
+		payload.Data.Viewer.DatabaseID = 77
+		payload.Data.Repository.PullRequest.Reviews.Nodes = []pendingReviewNode{
+			{
+				ID:                "RV_pending_99",
+				DatabaseID:        99,
+				State:             "PENDING",
+				AuthorAssociation: "MEMBER",
+				URL:               "https://example.com/review/99",
+				UpdatedAt:         "2024-06-02T12:00:00Z",
+				CreatedAt:         "2024-06-02T11:45:00Z",
+				Author: struct {
+					Login      string `json:"login"`
+					DatabaseID int64  `json:"databaseId"`
+				}{Login: "octocat", DatabaseID: 202},
+			},
+		}
+		payload.Data.Repository.PullRequest.Reviews.PageInfo.HasNextPage = false
+		payload.Data.Repository.PullRequest.Reviews.PageInfo.EndCursor = ""
+		return assign(result, payload)
+	}
 	api.restFunc = func(method, path string, params map[string]string, body interface{}, result interface{}) error {
 		switch {
 		case path == "user":
@@ -291,6 +359,45 @@ func TestServiceReply_AutoSubmitPending(t *testing.T) {
 
 func TestServiceReply_PendingMissing(t *testing.T) {
 	api := &fakeAPI{}
+	api.graphqlFunc = func(query string, variables map[string]interface{}, result interface{}) error {
+		if !strings.Contains(query, "PendingReviews") {
+			return errors.New("unexpected query")
+		}
+		require.Equal(t, "octo", variables["owner"])
+		require.Equal(t, "demo", variables["name"])
+		require.EqualValues(t, 7, variables["number"])
+		require.EqualValues(t, 100, variables["pageSize"])
+		_, hasCursor := variables["cursor"]
+		require.False(t, hasCursor)
+		_, hasAuthor := variables["author"]
+		require.False(t, hasAuthor)
+
+		payload := struct {
+			Data struct {
+				Viewer struct {
+					Login      string `json:"login"`
+					DatabaseID int64  `json:"databaseId"`
+				} `json:"viewer"`
+				Repository struct {
+					PullRequest struct {
+						Reviews struct {
+							Nodes    []pendingReviewNode `json:"nodes"`
+							PageInfo struct {
+								HasNextPage bool   `json:"hasNextPage"`
+								EndCursor   string `json:"endCursor"`
+							} `json:"pageInfo"`
+						} `json:"reviews"`
+					} `json:"pullRequest"`
+				} `json:"repository"`
+			} `json:"data"`
+		}{}
+		payload.Data.Viewer.Login = "casey"
+		payload.Data.Viewer.DatabaseID = 77
+		payload.Data.Repository.PullRequest.Reviews.Nodes = nil
+		payload.Data.Repository.PullRequest.Reviews.PageInfo.HasNextPage = false
+		payload.Data.Repository.PullRequest.Reviews.PageInfo.EndCursor = ""
+		return assign(result, payload)
+	}
 	api.restFunc = func(method, path string, params map[string]string, body interface{}, result interface{}) error {
 		switch path {
 		case "repos/octo/demo/pulls/7/comments/5/replies":
@@ -312,5 +419,5 @@ func TestServiceReply_PendingMissing(t *testing.T) {
 	pr := resolver.Identity{Owner: "octo", Repo: "demo", Number: 7, Host: "github.com"}
 	_, err := svc.Reply(pr, ReplyOptions{CommentID: 5, Body: "ack"})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "pending reviews owned by octocat")
+	assert.Contains(t, err.Error(), "no pending reviews for octocat")
 }

--- a/internal/review/pending_test.go
+++ b/internal/review/pending_test.go
@@ -1,8 +1,6 @@
 package review
 
 import (
-	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/Agyn-sandbox/gh-pr-review/internal/resolver"
@@ -10,53 +8,87 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type testReviewNode struct {
+	ID                string `json:"id"`
+	DatabaseID        int64  `json:"databaseId"`
+	State             string `json:"state"`
+	AuthorAssociation string `json:"authorAssociation"`
+	URL               string `json:"url"`
+	UpdatedAt         string `json:"updatedAt"`
+	CreatedAt         string `json:"createdAt"`
+	Author            struct {
+		Login      string `json:"login"`
+		DatabaseID int64  `json:"databaseId"`
+	} `json:"author"`
+}
+
 func TestLatestPendingDefaultsToAuthenticatedReviewer(t *testing.T) {
 	api := &fakeAPI{}
-	api.restFunc = func(method, path string, params map[string]string, body interface{}, result interface{}) error {
-		switch path {
-		case "user":
-			return assign(result, map[string]interface{}{"login": "casey"})
-		case "repos/octo/demo/pulls/7/reviews":
-			require.Equal(t, "100", params["per_page"])
-			switch params["page"] {
-			case "1":
-				payload := []map[string]interface{}{
-					{
-						"id":                 5,
-						"node_id":            "R_pending_5",
-						"state":              "PENDING",
-						"author_association": "MEMBER",
-						"html_url":           "https://github.com/octo/demo/pull/7#review-5",
-						"user": map[string]interface{}{
-							"login": "casey",
-							"id":    101,
-						},
-					},
-					{
-						"id":                 7,
-						"node_id":            "R_pending_7",
-						"state":              "PENDING",
-						"author_association": "MEMBER",
-						"html_url":           "https://github.com/octo/demo/pull/7#review-7",
-						"user": map[string]interface{}{
-							"login": "casey",
-							"id":    101,
-						},
-					},
-					{
-						"id":      9,
-						"node_id": "R_pending_9",
-						"state":   "PENDING",
-						"user":    map[string]interface{}{"login": "other"},
-					},
-				}
-				return assign(result, payload)
-			default:
-				return assign(result, []map[string]interface{}{})
-			}
-		default:
-			return errors.New("unexpected path")
+	calls := 0
+	api.graphqlFunc = func(query string, variables map[string]interface{}, result interface{}) error {
+		calls++
+		require.Equal(t, "octo", variables["owner"])
+		require.Equal(t, "demo", variables["name"])
+		require.EqualValues(t, 7, variables["number"])
+		require.EqualValues(t, 100, variables["pageSize"])
+		_, hasCursor := variables["cursor"]
+		require.False(t, hasCursor)
+
+		nodes := []testReviewNode{
+			{
+				ID:                "R_pending_5",
+				DatabaseID:        5,
+				State:             "PENDING",
+				AuthorAssociation: "MEMBER",
+				URL:               "https://github.com/octo/demo/pull/7#review-5",
+				UpdatedAt:         "",
+				CreatedAt:         "2024-06-01T10:00:00Z",
+				Author: struct {
+					Login      string `json:"login"`
+					DatabaseID int64  `json:"databaseId"`
+				}{Login: "casey", DatabaseID: 101},
+			},
+			{
+				ID:                "R_pending_7",
+				DatabaseID:        7,
+				State:             "PENDING",
+				AuthorAssociation: "MEMBER",
+				URL:               "https://github.com/octo/demo/pull/7#review-7",
+				UpdatedAt:         "2024-06-01T12:00:00Z",
+				CreatedAt:         "2024-06-01T11:00:00Z",
+				Author: struct {
+					Login      string `json:"login"`
+					DatabaseID int64  `json:"databaseId"`
+				}{Login: "casey", DatabaseID: 101},
+			},
 		}
+
+		payload := struct {
+			Data struct {
+				Viewer struct {
+					Login      string `json:"login"`
+					DatabaseID int64  `json:"databaseId"`
+				} `json:"viewer"`
+				Repository struct {
+					PullRequest struct {
+						Reviews struct {
+							Nodes    []testReviewNode `json:"nodes"`
+							PageInfo struct {
+								HasNextPage bool   `json:"hasNextPage"`
+								EndCursor   string `json:"endCursor"`
+							} `json:"pageInfo"`
+						} `json:"reviews"`
+					} `json:"pullRequest"`
+				} `json:"repository"`
+			} `json:"data"`
+		}{}
+		payload.Data.Viewer.Login = "casey"
+		payload.Data.Viewer.DatabaseID = 101
+		payload.Data.Repository.PullRequest.Reviews.Nodes = nodes
+		payload.Data.Repository.PullRequest.Reviews.PageInfo.HasNextPage = false
+		payload.Data.Repository.PullRequest.Reviews.PageInfo.EndCursor = ""
+
+		return assign(result, payload)
 	}
 
 	svc := NewService(api)
@@ -72,35 +104,92 @@ func TestLatestPendingDefaultsToAuthenticatedReviewer(t *testing.T) {
 	assert.Equal(t, int64(101), summary.User.ID)
 	assert.Equal(t, "https://github.com/octo/demo/pull/7#review-7", summary.HTMLURL)
 	assert.Equal(t, "MEMBER", summary.AuthorAssociation)
+	assert.Equal(t, 1, calls)
 }
 
 func TestLatestPendingWithReviewerOverride(t *testing.T) {
 	api := &fakeAPI{}
-	api.restFunc = func(method, path string, params map[string]string, body interface{}, result interface{}) error {
-		if path != "repos/octo/demo/pulls/7/reviews" {
-			return errors.New("unexpected path")
-		}
-		require.Equal(t, "50", params["per_page"])
-		require.Equal(t, "3", params["page"])
-		payload := []map[string]interface{}{
-			{
-				"id":                 42,
-				"node_id":            "R_pending_42",
-				"state":              "PENDING",
-				"author_association": "CONTRIBUTOR",
-				"html_url":           "https://example.com/review/42",
-				"user": map[string]interface{}{
-					"login": "octocat",
-					"id":    202,
+	page := 0
+	api.graphqlFunc = func(query string, variables map[string]interface{}, result interface{}) error {
+		page++
+		require.Equal(t, "octo", variables["owner"])
+		require.Equal(t, "demo", variables["name"])
+		require.EqualValues(t, 7, variables["number"])
+		require.EqualValues(t, 50, variables["pageSize"])
+
+		payload := struct {
+			Data struct {
+				Viewer struct {
+					Login      string `json:"login"`
+					DatabaseID int64  `json:"databaseId"`
+				} `json:"viewer"`
+				Repository struct {
+					PullRequest struct {
+						Reviews struct {
+							Nodes    []testReviewNode `json:"nodes"`
+							PageInfo struct {
+								HasNextPage bool   `json:"hasNextPage"`
+								EndCursor   string `json:"endCursor"`
+							} `json:"pageInfo"`
+						} `json:"reviews"`
+					} `json:"pullRequest"`
+				} `json:"repository"`
+			} `json:"data"`
+		}{}
+		payload.Data.Viewer.Login = "casey"
+		payload.Data.Viewer.DatabaseID = 101
+
+		if page == 1 {
+			_, hasCursor := variables["cursor"]
+			require.False(t, hasCursor)
+			nodes := []testReviewNode{
+				{
+					ID:                "R_pending_other",
+					DatabaseID:        9,
+					State:             "PENDING",
+					AuthorAssociation: "MEMBER",
+					URL:               "https://example.com/review/9",
+					UpdatedAt:         "2024-06-01T08:00:00Z",
+					CreatedAt:         "2024-06-01T07:00:00Z",
+					Author: struct {
+						Login      string `json:"login"`
+						DatabaseID int64  `json:"databaseId"`
+					}{Login: "someone", DatabaseID: 404},
 				},
-			},
+			}
+			payload.Data.Repository.PullRequest.Reviews.Nodes = nodes
+			payload.Data.Repository.PullRequest.Reviews.PageInfo.HasNextPage = true
+			payload.Data.Repository.PullRequest.Reviews.PageInfo.EndCursor = "CURSOR1"
+		} else {
+			cursorValue, hasCursor := variables["cursor"]
+			require.True(t, hasCursor)
+			require.Equal(t, "CURSOR1", cursorValue)
+			nodes := []testReviewNode{
+				{
+					ID:                "R_pending_42",
+					DatabaseID:        42,
+					State:             "PENDING",
+					AuthorAssociation: "CONTRIBUTOR",
+					URL:               "https://example.com/review/42",
+					UpdatedAt:         "2024-06-02T12:00:00Z",
+					CreatedAt:         "2024-06-02T11:30:00Z",
+					Author: struct {
+						Login      string `json:"login"`
+						DatabaseID int64  `json:"databaseId"`
+					}{Login: "octocat", DatabaseID: 202},
+				},
+			}
+			payload.Data.Repository.PullRequest.Reviews.Nodes = nodes
+			payload.Data.Repository.PullRequest.Reviews.PageInfo.HasNextPage = false
+			payload.Data.Repository.PullRequest.Reviews.PageInfo.EndCursor = ""
 		}
+
 		return assign(result, payload)
 	}
 
 	svc := NewService(api)
 	pr := resolver.Identity{Owner: "octo", Repo: "demo", Number: 7, Host: "github.com"}
-	summary, err := svc.LatestPending(pr, PendingOptions{Reviewer: "octocat", PerPage: 50, Page: 3})
+	summary, err := svc.LatestPending(pr, PendingOptions{Reviewer: "octocat", PerPage: 50})
 	require.NoError(t, err)
 	require.NotNil(t, summary)
 	assert.Equal(t, "R_pending_42", summary.ID)
@@ -109,24 +198,43 @@ func TestLatestPendingWithReviewerOverride(t *testing.T) {
 	assert.Equal(t, "octocat", summary.User.Login)
 	assert.Equal(t, int64(202), summary.User.ID)
 	assert.Equal(t, "https://example.com/review/42", summary.HTMLURL)
+	assert.Equal(t, "CONTRIBUTOR", summary.AuthorAssociation)
+	assert.Equal(t, 2, page)
 }
 
 func TestLatestPendingNoMatches(t *testing.T) {
 	api := &fakeAPI{}
-	api.restFunc = func(method, path string, params map[string]string, body interface{}, result interface{}) error {
-		switch path {
-		case "user":
-			return assign(result, map[string]interface{}{"login": "casey"})
-		case "repos/octo/demo/pulls/7/reviews":
-			return assign(result, []map[string]interface{}{})
-		default:
-			return fmt.Errorf("unexpected path %s", path)
-		}
+	api.graphqlFunc = func(query string, variables map[string]interface{}, result interface{}) error {
+		payload := struct {
+			Data struct {
+				Viewer struct {
+					Login      string `json:"login"`
+					DatabaseID int64  `json:"databaseId"`
+				} `json:"viewer"`
+				Repository struct {
+					PullRequest struct {
+						Reviews struct {
+							Nodes    []testReviewNode `json:"nodes"`
+							PageInfo struct {
+								HasNextPage bool   `json:"hasNextPage"`
+								EndCursor   string `json:"endCursor"`
+							} `json:"pageInfo"`
+						} `json:"reviews"`
+					} `json:"pullRequest"`
+				} `json:"repository"`
+			} `json:"data"`
+		}{}
+		payload.Data.Viewer.Login = "casey"
+		payload.Data.Viewer.DatabaseID = 101
+		payload.Data.Repository.PullRequest.Reviews.Nodes = []testReviewNode{}
+		payload.Data.Repository.PullRequest.Reviews.PageInfo.HasNextPage = false
+		payload.Data.Repository.PullRequest.Reviews.PageInfo.EndCursor = ""
+		return assign(result, payload)
 	}
 
 	svc := NewService(api)
 	pr := resolver.Identity{Owner: "octo", Repo: "demo", Number: 7, Host: "github.com"}
 	_, err := svc.LatestPending(pr, PendingOptions{})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no pending reviews")
+	assert.Contains(t, err.Error(), "no pending reviews for casey")
 }


### PR DESCRIPTION
## Summary
- remove REST fallbacks from submit and pending review flows
- implement GraphQL-only pagination/validation for pending reviews and comments auto-submit
- refresh docs and CLI tests to describe GraphQL-only behavior

Resolves #34.

## Testing
- gofmt -w cmd/review.go cmd/review_test.go internal/comments/service.go internal/comments/service_test.go internal/review/service.go internal/review/service_test.go internal/review/pending.go internal/review/pending_test.go
- go test ./...
