### PR TITLE
fix: graphql viewer login fragments

### DIFF
--- a/cmd/review_test.go
+++ b/cmd/review_test.go
@@ -417,12 +417,19 @@ func TestReviewPendingIDCommand_GraphQLOnly(t *testing.T) {
 
 	fake := &commandFakeAPI{}
 	fake.graphqlFunc = func(query string, variables map[string]interface{}, result interface{}) error {
+		if strings.Contains(query, "ViewerLogin") {
+			payload := obj{
+				"data": obj{
+					"viewer": obj{
+						"login": "casey",
+					},
+				},
+			}
+			return assignJSON(result, payload)
+		}
+
 		payload := obj{
 			"data": obj{
-				"viewer": obj{
-					"login":      "casey",
-					"databaseId": 77,
-				},
 				"repository": obj{
 					"pullRequest": obj{
 						"reviews": obj{
@@ -433,8 +440,7 @@ func TestReviewPendingIDCommand_GraphQLOnly(t *testing.T) {
 									"url":        "https://example.com/review/10",
 									"state":      "PENDING",
 									"author": obj{
-										"login":      "casey",
-										"databaseId": 77,
+										"login": "casey",
 									},
 									"updatedAt": "2024-06-01T12:00:00Z",
 									"createdAt": "2024-06-01T11:00:00Z",
@@ -445,8 +451,7 @@ func TestReviewPendingIDCommand_GraphQLOnly(t *testing.T) {
 									"url":        "https://example.com/review/22",
 									"state":      "PENDING",
 									"author": obj{
-										"login":      "casey",
-										"databaseId": 77,
+										"login": "casey",
 									},
 									"updatedAt": "2024-06-01T13:00:00Z",
 									"createdAt": "2024-06-01T12:30:00Z",
@@ -486,5 +491,6 @@ func TestReviewPendingIDCommand_GraphQLOnly(t *testing.T) {
 	user, ok := payload["user"].(obj)
 	require.True(t, ok)
 	assert.Equal(t, "casey", user["login"])
-	assert.Equal(t, float64(77), user["id"])
+	_, hasID := user["id"]
+	assert.False(t, hasID)
 }

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -246,7 +246,7 @@ func (s *Service) Submit(pr resolver.Identity, input SubmitInput) (*ReviewState,
 }
 
 func (s *Service) lookupLatestNonPendingByViewer(pr resolver.Identity) (*ReviewState, error) {
-	login, err := s.resolveViewerLogin()
+	login, err := s.currentViewer()
 	if err != nil {
 		return nil, err
 	}
@@ -329,7 +329,7 @@ func (s *Service) lookupLatestNonPendingByViewer(pr resolver.Identity) (*ReviewS
 	return &state, nil
 }
 
-func (s *Service) resolveViewerLogin() (string, error) {
+func (s *Service) currentViewer() (string, error) {
 	const query = `query ViewerLogin { viewer { login } }`
 
 	var response struct {


### PR DESCRIPTION
## Summary
- query review authors with inline fragments and stop requesting viewer databaseId
- share a currentViewer helper returning the authenticated login for pending lookups
- relax CLI/test expectations so user IDs are optional under GraphQL-only flows

Resolves #38.

## Testing
- gofmt -w internal/review/pending.go internal/review/service.go internal/review/pending_test.go cmd/review_test.go
- go test ./...
