### PR TITLE
feat(review): enforce backend per command

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,16 @@ gh pr-review review --add-comment \
   --body "nit: use helper" \
   owner/repo#42
 
-# Submit the review with a specific event
+# Submit the review with a specific event (REST review ID required)
 gh pr-review review --submit \
-  --review-id R_kwM123456789 \
+  --review-id 3531807471 \
   --event REQUEST_CHANGES \
   --body "Please update tests" \
   owner/repo#42
+
+The `--review-id` flag accepts different identifier types depending on the
+action: use the numeric REST review ID when submitting, and GraphQL review node
+IDs for operations like `--add-comment`.
 ```
 
 ### Manage review threads
@@ -121,8 +125,9 @@ gh pr-review threads find --comment_id 2582545223 owner/repo#42
 Outputs are pure JSON with REST/GraphQL field names and include only fields that
 are present from the source APIs (no null placeholders). Pending-review helpers
 use GitHub's GraphQL API exclusively and fail fast if required payloads are
-missing. The `threads find` command always emits exactly `{ "id",
-"isResolved" }`.
+missing. When the authenticated viewer login cannot be determined, the command
+exits with guidance to pass `--reviewer`. The `threads find` command always
+emits exactly `{ "id", "isResolved" }`.
 
 ## Output conventions
 

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -35,7 +35,7 @@ func newReviewCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.Submit, "submit", false, "Submit a pending review")
 
 	cmd.Flags().StringVar(&opts.Commit, "commit", "", "Commit SHA for review start (defaults to current head)")
-	cmd.Flags().StringVar(&opts.ReviewID, "review-id", "", "Review identifier")
+	cmd.Flags().StringVar(&opts.ReviewID, "review-id", "", "Review identifier (REST review ID for --submit; GraphQL ID for --add-comment)")
 	cmd.Flags().StringVar(&opts.Path, "path", "", "File path for inline comment")
 	cmd.Flags().IntVar(&opts.Line, "line", 0, "Line number for inline comment")
 	cmd.Flags().StringVar(&opts.Side, "side", opts.Side, "Diff side for inline comment (LEFT or RIGHT)")
@@ -236,6 +236,9 @@ func runReviewPendingID(cmd *cobra.Command, opts *reviewPendingOptions) error {
 		PerPage:  opts.PerPage,
 	})
 	if err != nil {
+		if strings.TrimSpace(opts.Reviewer) == "" && errors.Is(err, reviewsvc.ErrViewerLoginUnavailable) {
+			return fmt.Errorf("unable to resolve reviewer automatically; pass --reviewer or ensure gh auth login is active")
+		}
 		return err
 	}
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -23,7 +23,7 @@ gh pr-review review --add-comment \
 
 # Submit the review (COMMENT | APPROVE | REQUEST_CHANGES)
 gh pr-review review --submit \
-  --review-id R_kwM123456 \
+  --review-id 3531807471 \
   --event APPROVE \
   --body "Looks good" \
   owner/repo#42
@@ -32,8 +32,11 @@ gh pr-review review --submit \
 gh pr-review review pending-id --reviewer octocat owner/repo#42
 ```
 
-> **Note:** Pending-review helpers use GitHub's GraphQL API exclusively. The
-> command fails fast if the GraphQL payload omits the requested review data.
+> **Note:** `--review-id` expects a REST review database ID when submitting and
+> the GraphQL review node ID when adding inline comments. Pending-review
+> helpers use GitHub's GraphQL API exclusively. They fail fast if the payload is
+> missing required data or the authenticated viewer login cannot be resolved—
+> pass `--reviewer` in that scenario.
 
 ## 2. Read and reply to inline comments
 


### PR DESCRIPTION
## Summary
- enforce REST workflow for review --submit requests and remove GraphQL fallback
- add pending-id viewer guidance and clarify review-id semantics across CLI/docs
- refresh service and command tests for backend-only execution paths

## Testing
- go test ./...

Resolves #41