### PR TITLE
Fix review GraphQL start/add-comment outputs

### DIFF
--- a/cmd/review.go
+++ b/cmd/review.go
@@ -114,6 +114,14 @@ func executeReviewStart(cmd *cobra.Command, service *reviewsvc.Service, pr resol
 }
 
 func executeReviewAddComment(cmd *cobra.Command, service *reviewsvc.Service, pr resolver.Identity, opts *reviewOptions) error {
+	reviewID := strings.TrimSpace(opts.ReviewID)
+	if reviewID == "" {
+		return errors.New("--review-id is required")
+	}
+	if !strings.HasPrefix(reviewID, "PRR_") {
+		return fmt.Errorf("invalid --review-id %q: must be a GraphQL node id (PRR_...)", opts.ReviewID)
+	}
+
 	side, err := normalizeSide(opts.Side)
 	if err != nil {
 		return err
@@ -132,7 +140,7 @@ func executeReviewAddComment(cmd *cobra.Command, service *reviewsvc.Service, pr 
 	}
 
 	input := reviewsvc.ThreadInput{
-		ReviewID:  strings.TrimSpace(opts.ReviewID),
+		ReviewID:  reviewID,
 		Path:      strings.TrimSpace(opts.Path),
 		Line:      opts.Line,
 		Side:      side,


### PR DESCRIPTION
## Summary
- update review start to resolve PR identifiers via GraphQL and ensure pending review responses carry non-empty metadata
- enforce GraphQL review node IDs for add-comment and surface thread data directly from the GraphQL mutation
- expand service and CLI coverage for the GraphQL-only flows and error handling

## Testing
- CGO_ENABLED=0 go test ./...
- CGO_ENABLED=0 golangci-lint run
- CGO_ENABLED=0 go run . review --start agyn-sandbox/gh-pr-review-e2e-tmp-20251203#6
- CGO_ENABLED=0 go run . review --add-comment --review-id PRR_kwDOQh_tm87TEWuR --path scenario.md --line 5 --body "GraphQL add comment test L5" agyn-sandbox/gh-pr-review-e2e-tmp-20251203#6
- CGO_ENABLED=0 go run . review --add-comment --review-id PRR_kwDOQh_tm87TEWuR --path scenario.md --line 13 --body "GraphQL add comment test L13" agyn-sandbox/gh-pr-review-e2e-tmp-20251203#6
- CGO_ENABLED=0 go run . review --add-comment --review-id PRR_kwDOQh_tm87TEWuR --path scenario.md --line 21 --body "GraphQL add comment test L21" agyn-sandbox/gh-pr-review-e2e-tmp-20251203#6

Resolves #43
