### PR TITLE
docs: document v1.2.1 usage

### DIFF
--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -1,0 +1,396 @@
+# Output schemas (v1.2.1)
+
+Optional fields are omitted entirely (never serialized as `null`). Unless noted,
+schemas disallow additional properties to surface unexpected payload changes.
+
+## ReviewState
+
+Used by `review --start` and `review --submit`.
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ReviewState",
+  "type": "object",
+  "required": ["id", "state"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "GraphQL review node identifier (PRR_…)"
+    },
+    "state": {
+      "type": "string",
+      "enum": ["PENDING", "COMMENTED", "APPROVED", "DISMISSED", "REQUEST_CHANGES"]
+    },
+    "submitted_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "RFC3339 timestamp of the submission (omitted when pending)"
+    },
+    "database_id": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "REST review identifier"
+    },
+    "html_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "Link to the review on GitHub"
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+## ReviewThread
+
+Produced by `review --add-comment`.
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ReviewThread",
+  "type": "object",
+  "required": ["id", "path", "is_outdated"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "GraphQL review thread node identifier"
+    },
+    "path": {
+      "type": "string",
+      "description": "File path for the inline thread"
+    },
+    "is_outdated": {
+      "type": "boolean"
+    },
+    "line": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Updated diff line (omitted for multi-line threads)"
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+## PendingSummary
+
+Emitted by `review pending-id`.
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "PendingSummary",
+  "type": "object",
+  "required": ["id", "database_id", "state"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "GraphQL review node identifier"
+    },
+    "database_id": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "REST review identifier"
+    },
+    "state": {
+      "type": "string",
+      "enum": ["PENDING"],
+      "description": "Pending review state"
+    },
+    "author_association": {
+      "type": "string",
+      "description": "GitHub author association (MEMBER, CONTRIBUTOR, …)"
+    },
+    "html_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "Direct link to the review"
+    },
+    "user": {
+      "$ref": "#/$defs/ReviewUser"
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "ReviewUser": {
+      "type": "object",
+      "properties": {
+        "login": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}
+```
+
+## CommentReference
+
+Returned by `comments ids`.
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "CommentReference",
+  "type": "object",
+  "required": ["id", "body"],
+  "properties": {
+    "id": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "body": {
+      "type": "string"
+    },
+    "user": {
+      "$ref": "#/$defs/CommentAuthor"
+    },
+    "author_association": {
+      "type": "string"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "html_url": {
+      "type": "string",
+      "format": "uri"
+    },
+    "path": {
+      "type": "string"
+    },
+    "line": {
+      "type": "integer",
+      "minimum": 1
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "CommentAuthor": {
+      "type": "object",
+      "properties": {
+        "login": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}
+```
+
+## ReplyComment
+
+Default payload from `comments reply`.
+
+This schema captures the stable subset that the extension relies on while
+allowing additional GitHub REST fields to pass through unchanged.
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ReplyComment",
+  "type": "object",
+  "required": [
+    "id",
+    "node_id",
+    "pull_request_review_id",
+    "body",
+    "user",
+    "path",
+    "html_url",
+    "created_at",
+    "updated_at"
+  ],
+  "properties": {
+    "id": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "node_id": {
+      "type": "string"
+    },
+    "pull_request_review_id": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "in_reply_to_id": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "body": {
+      "type": "string"
+    },
+    "user": {
+      "$ref": "#/$defs/ReplyUser"
+    },
+    "diff_hunk": {
+      "type": "string"
+    },
+    "path": {
+      "type": "string"
+    },
+    "line": {
+      "type": ["integer", "null"],
+      "description": "Replies inside threads may omit diff coordinates"
+    },
+    "side": {
+      "type": ["string", "null"],
+      "enum": ["LEFT", "RIGHT", null]
+    },
+    "html_url": {
+      "type": "string",
+      "format": "uri"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "additionalProperties": true,
+  "$defs": {
+    "ReplyUser": {
+      "type": "object",
+      "properties": {
+        "login": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "required": ["login", "id"],
+      "additionalProperties": true
+    }
+  }
+}
+```
+
+## ReplyConcise
+
+Minimal payload from `comments reply --concise`.
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ReplyConcise",
+  "type": "object",
+  "required": ["id"],
+  "properties": {
+    "id": {
+      "type": "integer",
+      "minimum": 1
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+## ThreadSummary
+
+Returned by `threads list`.
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ThreadSummary",
+  "type": "object",
+  "required": ["threadId", "isResolved", "path", "isOutdated"],
+  "properties": {
+    "threadId": {
+      "type": "string"
+    },
+    "isResolved": {
+      "type": "boolean"
+    },
+    "resolvedBy": {
+      "type": "string",
+      "description": "Login of the user who resolved the thread"
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "path": {
+      "type": "string"
+    },
+    "line": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "isOutdated": {
+      "type": "boolean"
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+## ThreadActionResult
+
+Emitted by `threads resolve` and `threads unresolve`.
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ThreadActionResult",
+  "type": "object",
+  "required": ["threadId", "isResolved", "changed"],
+  "properties": {
+    "threadId": {
+      "type": "string"
+    },
+    "isResolved": {
+      "type": "boolean"
+    },
+    "changed": {
+      "type": "boolean",
+      "description": "False when the thread already matched the requested state"
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+## ThreadFindResult
+
+Returned by `threads find` and used internally when mapping REST comment IDs to
+GraphQL threads.
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ThreadFindResult",
+  "type": "object",
+  "required": ["id", "isResolved"],
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "isResolved": {
+      "type": "boolean"
+    }
+  },
+  "additionalProperties": false
+}
+```

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,270 @@
+# Usage reference (v1.2.1)
+
+All commands accept pull request selectors in any GitHub CLI format:
+
+- `owner/repo#123`
+- a pull request URL (`https://github.com/owner/repo/pull/123`)
+- `-R owner/repo 123`
+
+Unless stated otherwise, commands emit JSON only. Optional fields are omitted
+instead of serializing as `null`. Array responses default to `[]`.
+
+## review --start (GraphQL only)
+
+- **Purpose:** Open (or resume) a pending review on the head commit.
+- **Inputs:**
+  - Optional pull request selector argument.
+  - `--repo` / `--pr` flags when not using the selector shorthand.
+  - `--commit` to pin the pending review to a specific commit SHA (defaults to
+    the pull request head).
+- **Backend:** GitHub GraphQL `addPullRequestReview` mutation.
+- **Output schema:** [`ReviewState`](SCHEMAS.md#reviewstate) — required fields
+  `id` and `state`; optional `submitted_at`, `database_id`, `html_url`.
+
+```sh
+gh pr-review review --start owner/repo#42
+
+{
+  "id": "PRR_kwDOAAABbcdEFG12",
+  "state": "PENDING",
+  "database_id": 3531807471,
+  "html_url": "https://github.com/owner/repo/pull/42#pullrequestreview-3531807471"
+}
+```
+
+## review --add-comment (GraphQL only)
+
+- **Purpose:** Attach an inline thread to an existing pending review.
+- **Inputs:**
+  - `--review-id` **(required):** GraphQL review node ID (must start with
+    `PRR_`). Numeric IDs are rejected.
+  - `--path`, `--line`, `--body` **(required).**
+  - `--side`, `--start-line`, `--start-side` to describe diff positioning.
+- **Backend:** GitHub GraphQL `addPullRequestReviewThread` mutation.
+- **Output schema:** [`ReviewThread`](SCHEMAS.md#reviewthread) — required fields
+  `id`, `path`, `is_outdated`; optional `line`.
+
+```sh
+gh pr-review review --add-comment \
+  --review-id PRR_kwDOAAABbcdEFG12 \
+  --path internal/service.go \
+  --line 42 \
+  --body "nit: prefer helper" \
+  owner/repo#42
+
+{
+  "id": "PRRT_kwDOAAABbcdEFG12",
+  "path": "internal/service.go",
+  "is_outdated": false,
+  "line": 42
+}
+```
+
+## review pending-id (GraphQL only)
+
+- **Purpose:** Locate the latest pending review for a reviewer.
+- **Inputs:**
+  - Optional reviewer login via `--reviewer`.
+  - `--per_page` to adjust GraphQL pagination size (default 100).
+- **Backend:** GitHub GraphQL `pullRequest.reviews(states: [PENDING])` query.
+- **Behavior:**
+  - Defaults to the authenticated viewer. If the viewer login cannot be
+    retrieved, the command fails with guidance to pass `--reviewer`.
+  - Fails when no pending review exists for the requested reviewer.
+- **Output schema:** [`PendingSummary`](SCHEMAS.md#pendingsummary) — required
+  `id`, `database_id`, `state`; optional `author_association`, `html_url`,
+  nested `user` object.
+
+```sh
+gh pr-review review pending-id --reviewer octocat owner/repo#42
+
+{
+  "id": "PRR_kwDOAAABbcdEFG12",
+  "database_id": 3531807471,
+  "state": "PENDING",
+  "html_url": "https://github.com/owner/repo/pull/42#pullrequestreview-3531807471",
+  "user": { "login": "octocat", "id": 6752317 }
+}
+```
+
+## review --submit (REST only)
+
+- **Purpose:** Finalize a pending review as COMMENT, APPROVE, or
+  REQUEST_CHANGES.
+- **Inputs:**
+  - `--review-id` **(required):** Numeric REST identifier. GraphQL IDs are
+    rejected.
+  - `--event` **(required):** One of `COMMENT`, `APPROVE`, `REQUEST_CHANGES`.
+  - `--body`: Optional message. Required by GitHub when using
+    `REQUEST_CHANGES`.
+- **Backend:** GitHub REST APIs:
+  - `POST /repos/{owner}/{repo}/pulls/{number}/reviews/{id}/events`
+  - `GET /repos/{owner}/{repo}/pulls/{number}/reviews/{id}` (post-submit state)
+- **Output schema:** [`ReviewState`](SCHEMAS.md#reviewstate).
+
+```sh
+# COMMENT
+gh pr-review review --submit \
+  --review-id 3531807471 \
+  --event COMMENT \
+  --body "Looks great" \
+  owner/repo#42
+
+# APPROVE
+gh pr-review review --submit \
+  --review-id 3531807471 \
+  --event APPROVE \
+  owner/repo#42
+
+# REQUEST_CHANGES
+gh pr-review review --submit \
+  --review-id 3531807471 \
+  --event REQUEST_CHANGES \
+  --body "Please cover edge cases" \
+  owner/repo#42
+
+{
+  "id": "PRR_kwDOAAABbcdEFG12",
+  "state": "REQUEST_CHANGES",
+  "submitted_at": "2024-12-19T18:43:22Z",
+  "database_id": 3531807471,
+  "html_url": "https://github.com/owner/repo/pull/42#pullrequestreview-3531807471"
+}
+```
+
+## comments ids (REST)
+
+- **Purpose:** Emit minimal metadata for review comments.
+- **Inputs:**
+  - `--review_id` to target a specific review (mutually exclusive with
+    `--latest`).
+  - `--latest` to resolve the latest submitted review for a reviewer (defaults
+    to the authenticated user; override with `--reviewer`).
+  - Pagination controls: `--limit`, `--per_page`, `--page`.
+- **Backend:** GitHub REST `GET /pulls/{number}/reviews/{id}/comments`.
+- **Output schema:** [`CommentReference`](SCHEMAS.md#commentreference) array.
+
+```sh
+gh pr-review comments ids \
+  --review_id 3531807471 \
+  --limit 2 \
+  owner/repo#42
+
+[
+  {
+    "id": 987654321,
+    "body": "nit: prefer helper",
+    "user": { "login": "octocat", "id": 6752317 },
+    "author_association": "MEMBER",
+    "created_at": "2024-12-19T18:33:10Z",
+    "updated_at": "2024-12-19T18:33:10Z",
+    "html_url": "https://github.com/owner/repo/pull/42#discussion_r987654321",
+    "path": "internal/service.go",
+    "line": 42
+  }
+]
+```
+
+## comments reply (REST, optional concise mode)
+
+- **Purpose:** Reply to a review comment.
+- **Inputs:**
+  - `--comment-id` **(required):** Numeric comment identifier.
+  - `--body` **(required).**
+  - `--concise`: Emit the minimal `{ "id": <reply-id> }` response.
+- **Backend:** GitHub REST `POST /pulls/comments/{comment_id}/replies`.
+- **Auto-submit behavior:** When GitHub blocks the reply because you own a
+  pending review, the extension uses GraphQL only to locate pending review IDs
+  and submits them via REST before retrying.
+- **Output schema:**
+  - Default: GitHub REST pull request review comment object (see
+    [`ReplyComment`](SCHEMAS.md#replycomment)).
+  - `--concise`: [`ReplyConcise`](SCHEMAS.md#replyconcise).
+
+```sh
+# Full REST payload
+gh pr-review comments reply \
+  --comment-id 987654321 \
+  --body "Thanks for catching this" \
+  owner/repo#42
+
+# Sample output (subset of fields; GitHub returns additional metadata)
+{
+  "id": 1122334455,
+  "node_id": "MDEyOkNvbW1lbnQxMTIyMzM0NDU1",
+  "pull_request_review_id": 3531807471,
+  "in_reply_to_id": 987654321,
+  "body": "Thanks for catching this",
+  "user": { "login": "octocat", "id": 6752317 },
+  "path": "internal/service.go",
+  "line": 42,
+  "side": "RIGHT",
+  "html_url": "https://github.com/owner/repo/pull/42#discussion_r1122334455",
+  "created_at": "2024-12-19T18:35:02Z",
+  "updated_at": "2024-12-19T18:35:02Z"
+}
+
+# Concise payload
+gh pr-review comments reply \
+  --comment-id 987654321 \
+  --body "Ack" \
+  --concise \
+  owner/repo#42
+
+{
+  "id": 123456789
+}
+```
+
+## threads list (GraphQL)
+
+- **Purpose:** Enumerate review threads for a pull request.
+- **Inputs:**
+  - `--unresolved` to filter unresolved threads only.
+  - `--mine` to include only threads you can resolve or participated in.
+- **Backend:** GitHub GraphQL `reviewThreads` query.
+- **Output schema:** Array of [`ThreadSummary`](SCHEMAS.md#threadsummary).
+
+```sh
+gh pr-review threads list --unresolved --mine owner/repo#42
+
+[
+  {
+    "threadId": "R_ywDoABC123",
+    "isResolved": false,
+    "updatedAt": "2024-12-19T18:40:11Z",
+    "path": "internal/service.go",
+    "line": 42,
+    "isOutdated": false
+  }
+]
+```
+
+## threads resolve / threads unresolve (GraphQL + REST lookup when needed)
+
+- **Purpose:** Resolve or reopen a review thread.
+- **Inputs:**
+  - Provide either `--thread-id` (GraphQL node) or `--comment-id` (REST review
+    comment). Supplying both is rejected.
+- **Backend:**
+  - GraphQL mutations `resolveReviewThread` / `unresolveReviewThread`.
+  - REST `GET /pulls/comments/{comment_id}` when mapping a numeric comment ID to
+    a thread node.
+- **Output schema:** [`ThreadActionResult`](SCHEMAS.md#threadactionresult).
+
+```sh
+# Resolve by GraphQL thread id
+gh pr-review threads resolve --thread-id R_ywDoABC123 owner/repo#42
+
+# Resolve by comment id (REST lookup + GraphQL mutation)
+gh pr-review threads resolve --comment-id 2582545223 owner/repo#42
+
+{
+  "threadId": "R_ywDoABC123",
+  "isResolved": true,
+  "changed": true
+}
+```
+
+`threads unresolve` emits the same schema, with `isResolved` equal to `false`
+after reopening the thread.


### PR DESCRIPTION
## Summary
- add quickstart, backend policy, and linux-arm64 build guidance to `README.md`
- document command inputs, behaviors, and examples in `docs/USAGE.md`
- publish formal JSON schemas in `docs/SCHEMAS.md` (optional) for v1.2.1

## Testing
- CGO_ENABLED=0 go test ./...
- CGO_ENABLED=0 golangci-lint run

Fixes #45
