### PR TITLE
feat: review report command

### DIFF
--- a/ENGINEER_REVIEW_GUIDE.md
+++ b/ENGINEER_REVIEW_GUIDE.md
@@ -1,0 +1,76 @@
+# Engineer Review Guide
+
+## `gh pr-review review report`
+
+High-level summary of the pull request review activity. The command issues a
+single GraphQL operation and emits JSON grouped by review → parent inline
+comment → thread replies.
+
+```bash
+gh pr-review review report <owner>/<repo>#<number>
+```
+
+### Default scope
+
+- Includes every reviewer and review state (APPROVED, CHANGES_REQUESTED,
+  COMMENTED, DISMISSED).
+- Threads are grouped by parent inline comment; replies are sorted by
+  `created_at` ascending.
+- Optional fields are omitted rather than rendered as `null`.
+
+### Useful filters
+
+| Flag | Description |
+| --- | --- |
+| `--reviewer <login>` | Limit to a specific reviewer login (case-insensitive). |
+| `--states <list>` | Comma-separated list of review states. |
+| `--unresolved` | Only include unresolved threads. |
+| `--not_outdated` | Drop threads marked as outdated. |
+| `--tail <n>` | Keep the last `n` replies per thread (0 keeps all). |
+
+Example capturing the latest actionable work:
+
+```bash
+gh pr-review review report agyn/repo#51 \
+  --reviewer emerson \
+  --states CHANGES_REQUESTED,COMMENTED \
+  --unresolved \
+  --not_outdated \
+  --tail 2
+```
+
+### Output schema
+
+```json
+{
+  "reviews": [
+    {
+      "id": "PRR_…",
+      "state": "COMMENTED",
+      "submitted_at": "2025-12-03T10:00:00Z",
+      "author_login": "emerson",
+      "comments": [
+        {
+          "id": 123456789,
+          "path": "internal/service.go",
+          "line": 42,
+          "is_resolved": false,
+          "is_outdated": false,
+          "thread": [
+            {
+              "id": 123456790,
+              "in_reply_to_id": 123456789,
+              "author_login": "casey",
+              "body": "Followed up in commit abc123",
+              "created_at": "2025-12-03T10:05:00Z"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+Empty optional fields are omitted from the JSON payload (for example, `body` and
+`submitted_at` are only emitted when the data is present).

--- a/MCP_REVIEW_GUIDE.md
+++ b/MCP_REVIEW_GUIDE.md
@@ -1,0 +1,73 @@
+# MCP Review Guide
+
+## Quick reference: `gh pr-review review report`
+
+The command is GraphQL-only and performs a single query per invocation. It
+returns structured JSON that is agent-friendly and omits nullable fields.
+
+### Invocation pattern
+
+```json
+{
+  "cmd": [
+    "gh", "pr-review", "review", "report",
+    "agyn/repo#51",
+    "--reviewer", "casey",
+    "--states", "CHANGES_REQUESTED,COMMENTED",
+    "--unresolved",
+    "--not_outdated",
+    "--tail", "5"
+  ]
+}
+```
+
+### Response shape
+
+`reviews[]` → `comments[]` → `thread[]`:
+
+```json
+{
+  "id": "PRR_kwDOAAABbcdEFG12",
+  "state": "COMMENTED",
+  "author_login": "casey",
+  "submitted_at": "2025-12-03T10:00:00Z",
+  "comments": [
+    {
+      "id": 3531807471,
+      "path": "internal/service.go",
+      "line": 42,
+      "is_resolved": false,
+      "is_outdated": false,
+      "thread": [
+        {
+          "id": 3531807472,
+          "in_reply_to_id": 3531807471,
+          "author_login": "emerson",
+          "body": "Can we reuse the helper?",
+          "created_at": "2025-12-03T10:05:00Z"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Optional properties (`body`, `submitted_at`, `line`, `in_reply_to_id`,
+`comments`) are omitted instead of set to `null`. Empty reply arrays are
+serialized as `"thread": []`.
+
+### Filtering cheatsheet
+
+- `--reviewer <login>` — narrow to a single reviewer (case-insensitive).
+- `--states <comma list>` — choose from `APPROVED`, `CHANGES_REQUESTED`,
+  `COMMENTED`, `DISMISSED`.
+- `--unresolved` — drop resolved threads.
+- `--not_outdated` — drop outdated threads.
+- `--tail <n>` — keep the last `n` replies per thread (omit to show all).
+
+### Failure modes
+
+- Missing authentication token: surfaced directly from the underlying `gh` CLI.
+- Unknown review state value: the command exits non-zero with a descriptive
+  validation error before calling GraphQL.
+- Pull request not accessible: returns `pull request not found or inaccessible`.

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -46,6 +46,7 @@ func newReviewCommand() *cobra.Command {
 
 	cmd.AddCommand(newReviewLatestIDCommand())
 	cmd.AddCommand(newReviewPendingIDCommand())
+	cmd.AddCommand(newReviewReportCommand())
 
 	return cmd
 }

--- a/cmd/review_report.go
+++ b/cmd/review_report.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Agyn-sandbox/gh-pr-review/internal/report"
+	"github.com/Agyn-sandbox/gh-pr-review/internal/resolver"
+)
+
+func newReviewReportCommand() *cobra.Command {
+	opts := &reviewReportOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "report [<number> | <url> | <owner>/<repo>#<number>]",
+		Short: "Generate a structured review report (GraphQL)",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				opts.Selector = args[0]
+			}
+			return runReviewReport(cmd, opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Repo, "repo", "R", "", "Repository in 'owner/repo' format")
+	cmd.Flags().IntVar(&opts.Pull, "pr", 0, "Pull request number")
+	cmd.Flags().StringVar(&opts.Reviewer, "reviewer", "", "Filter to a specific reviewer (login)")
+	cmd.Flags().StringSliceVar(&opts.States, "states", nil, "Comma-separated review states (APPROVED, CHANGES_REQUESTED, COMMENTED, DISMISSED)")
+	cmd.Flags().BoolVar(&opts.Unresolved, "unresolved", false, "Only include unresolved threads")
+	cmd.Flags().BoolVar(&opts.NotOutdated, "not_outdated", false, "Exclude outdated threads")
+	cmd.Flags().IntVar(&opts.TailReplies, "tail", 0, "Limit to the last N replies per thread (0 = all)")
+
+	return cmd
+}
+
+type reviewReportOptions struct {
+	Repo        string
+	Pull        int
+	Selector    string
+	Reviewer    string
+	States      []string
+	Unresolved  bool
+	NotOutdated bool
+	TailReplies int
+}
+
+func runReviewReport(cmd *cobra.Command, opts *reviewReportOptions) error {
+	if opts.TailReplies < 0 {
+		return fmt.Errorf("invalid --tail value %d: must be non-negative", opts.TailReplies)
+	}
+
+	selector, err := resolver.NormalizeSelector(opts.Selector, opts.Pull)
+	if err != nil {
+		return err
+	}
+
+	states, statesProvided, err := parseStateFilters(opts.States)
+	if err != nil {
+		return err
+	}
+
+	identity, err := resolver.Resolve(selector, opts.Repo, os.Getenv("GH_HOST"))
+	if err != nil {
+		return err
+	}
+
+	service := report.NewService(apiClientFactory(identity.Host))
+	output, err := service.Fetch(identity, report.Options{
+		Reviewer:           strings.TrimSpace(opts.Reviewer),
+		States:             states,
+		StatesProvided:     statesProvided,
+		RequireUnresolved:  opts.Unresolved,
+		RequireNotOutdated: opts.NotOutdated,
+		TailReplies:        opts.TailReplies,
+	})
+	if err != nil {
+		return err
+	}
+
+	return encodeJSON(cmd, output)
+}
+
+func parseStateFilters(raw []string) ([]report.State, bool, error) {
+	if len(raw) == 0 {
+		return nil, false, nil
+	}
+
+	valid := map[string]report.State{
+		"APPROVED":          report.StateApproved,
+		"CHANGES_REQUESTED": report.StateChangesRequested,
+		"COMMENTED":         report.StateCommented,
+		"DISMISSED":         report.StateDismissed,
+	}
+	allowed := make([]string, 0, len(valid))
+	for key := range valid {
+		allowed = append(allowed, key)
+	}
+	sort.Strings(allowed)
+
+	temp := make(map[report.State]struct{})
+	states := make([]report.State, 0, len(raw))
+	for _, entry := range raw {
+		parts := strings.Split(entry, ",")
+		for _, part := range parts {
+			candidate := strings.ToUpper(strings.TrimSpace(part))
+			if candidate == "" {
+				continue
+			}
+			state, ok := valid[candidate]
+			if !ok {
+				return nil, false, fmt.Errorf("invalid review state %q (allowed: %s)", part, strings.Join(allowed, ", "))
+			}
+			if _, seen := temp[state]; seen {
+				continue
+			}
+			temp[state] = struct{}{}
+			states = append(states, state)
+		}
+	}
+
+	if len(states) == 0 {
+		return nil, false, fmt.Errorf("no valid states provided")
+	}
+
+	return states, true, nil
+}

--- a/cmd/review_report_test.go
+++ b/cmd/review_report_test.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+
+	_ "embed"
+
+	"github.com/Agyn-sandbox/gh-pr-review/internal/ghcli"
+)
+
+//go:embed testdata/report_response.json
+var reportResponse []byte
+
+func TestReviewReportCommandFiltersOutput(t *testing.T) {
+	originalFactory := apiClientFactory
+	defer func() { apiClientFactory = originalFactory }()
+
+	fake := &fakeReportAPI{payload: reportResponse, t: t}
+	apiClientFactory = func(host string) ghcli.API {
+		if host == "" {
+			t.Fatalf("expected host to be resolved, got empty")
+		}
+		return fake
+	}
+
+	root := newRootCommand()
+	buf := &bytes.Buffer{}
+	root.SetOut(buf)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{"review", "report", "agyn/repo#51", "--reviewer", "alice", "--states", "APPROVED,COMMENTED", "--not_outdated", "--tail", "1"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute command: %v", err)
+	}
+
+	var payload struct {
+		Reviews []struct {
+			ID       string  `json:"id"`
+			Body     *string `json:"body"`
+			Comments []struct {
+				ID     int `json:"id"`
+				Thread []struct {
+					ID int `json:"id"`
+				} `json:"thread"`
+			} `json:"comments"`
+		} `json:"reviews"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatalf("parse json: %v", err)
+	}
+	if len(payload.Reviews) != 1 {
+		t.Fatalf("expected 1 review in filtered output, got %d", len(payload.Reviews))
+	}
+	review := payload.Reviews[0]
+	if review.ID != "R1" {
+		t.Fatalf("expected review R1, got %s", review.ID)
+	}
+	if review.Body == nil {
+		t.Fatalf("expected review body to be present for R1")
+	}
+	if len(review.Comments) != 1 {
+		t.Fatalf("expected 1 comment for R1, got %d", len(review.Comments))
+	}
+	if len(review.Comments[0].Thread) != 1 {
+		t.Fatalf("expected 1 reply after tail filter, got %d", len(review.Comments[0].Thread))
+	}
+	if review.Comments[0].Thread[0].ID != 303 {
+		t.Fatalf("expected reply id 303, got %d", review.Comments[0].Thread[0].ID)
+	}
+
+	rawStates, ok := fake.variables["states"].([]string)
+	if !ok || len(rawStates) != 2 {
+		t.Fatalf("expected states variable propagated, got %#v", fake.variables["states"])
+	}
+}
+
+func TestReviewReportCommandInvalidState(t *testing.T) {
+	root := newRootCommand()
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{"review", "report", "agyn/repo#51", "--states", "unknown"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error for invalid state")
+	}
+	if !strings.Contains(err.Error(), "invalid review state") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+type fakeReportAPI struct {
+	t         *testing.T
+	payload   []byte
+	variables map[string]interface{}
+}
+
+func (f *fakeReportAPI) REST(string, string, map[string]string, interface{}, interface{}) error {
+	f.t.Fatalf("unexpected REST call in report command")
+	return nil
+}
+
+func (f *fakeReportAPI) GraphQL(query string, variables map[string]interface{}, result interface{}) error {
+	f.variables = variables
+	return json.Unmarshal(f.payload, result)
+}

--- a/cmd/testdata/report_response.json
+++ b/cmd/testdata/report_response.json
@@ -1,0 +1,112 @@
+{
+  "repository": {
+    "pullRequest": {
+      "reviews": {
+        "nodes": [
+          {
+            "id": "R1",
+            "state": "APPROVED",
+            "body": "Looks good overall",
+            "submittedAt": "2025-12-03T10:00:00Z",
+            "databaseId": 101,
+            "author": { "login": "alice" }
+          },
+          {
+            "id": "R2",
+            "state": "COMMENTED",
+            "body": "",
+            "submittedAt": null,
+            "databaseId": 202,
+            "author": { "login": "bob" }
+          }
+        ]
+      },
+      "reviewThreads": {
+        "nodes": [
+          {
+            "id": "T1",
+            "path": "main.go",
+            "line": 42,
+            "isResolved": false,
+            "isOutdated": false,
+            "comments": {
+              "nodes": [
+                {
+                  "databaseId": 301,
+                  "body": "Parent comment 1",
+                  "createdAt": "2025-12-03T10:01:00Z",
+                  "author": { "login": "alice" },
+                  "pullRequestReview": {
+                    "id": "R1",
+                    "state": "APPROVED",
+                    "databaseId": 101
+                  },
+                  "replyTo": null
+                },
+                {
+                  "databaseId": 302,
+                  "body": "Reply alpha",
+                  "createdAt": "2025-12-03T10:02:00Z",
+                  "author": { "login": "bob" },
+                  "pullRequestReview": {
+                    "id": "R1",
+                    "state": "APPROVED",
+                    "databaseId": 101
+                  },
+                  "replyTo": { "databaseId": 301 }
+                },
+                {
+                  "databaseId": 303,
+                  "body": "Reply beta",
+                  "createdAt": "2025-12-03T10:03:00Z",
+                  "author": { "login": "alice" },
+                  "pullRequestReview": {
+                    "id": "R1",
+                    "state": "APPROVED",
+                    "databaseId": 101
+                  },
+                  "replyTo": { "databaseId": 302 }
+                }
+              ]
+            }
+          },
+          {
+            "id": "T2",
+            "path": "main.go",
+            "line": null,
+            "isResolved": true,
+            "isOutdated": true,
+            "comments": {
+              "nodes": [
+                {
+                  "databaseId": 401,
+                  "body": "Parent comment 2",
+                  "createdAt": "2025-12-03T10:04:00Z",
+                  "author": { "login": "bob" },
+                  "pullRequestReview": {
+                    "id": "R2",
+                    "state": "COMMENTED",
+                    "databaseId": 202
+                  },
+                  "replyTo": null
+                },
+                {
+                  "databaseId": 402,
+                  "body": "Reply gamma",
+                  "createdAt": "2025-12-03T10:05:00Z",
+                  "author": { "login": "alice" },
+                  "pullRequestReview": {
+                    "id": "R2",
+                    "state": "COMMENTED",
+                    "databaseId": 202
+                  },
+                  "replyTo": { "databaseId": 401 }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/internal/report/builder.go
+++ b/internal/report/builder.go
@@ -1,0 +1,153 @@
+package report
+
+import (
+	"sort"
+	"strings"
+	"time"
+)
+
+// BuildReport aggregates reviews and threads into the serialized report format.
+func BuildReport(reviews []Review, threads []Thread, filters FilterOptions) Report {
+	allowedStates := allowedStateSet(filters.States)
+
+	var reviewerFilter string
+	if filters.Reviewer != "" {
+		reviewerFilter = strings.ToLower(filters.Reviewer)
+	}
+
+	reportReviews := make([]ReportReview, 0, len(reviews))
+	reviewIndexByID := make(map[int]int, len(reviews))
+
+	for _, review := range reviews {
+		if _, ok := allowedStates[review.State]; !ok {
+			continue
+		}
+		if reviewerFilter != "" && strings.ToLower(review.AuthorLogin) != reviewerFilter {
+			continue
+		}
+
+		var submittedAt *string
+		if review.SubmittedAt != nil {
+			formatted := review.SubmittedAt.UTC().Format(time.RFC3339)
+			submittedAt = &formatted
+		}
+
+		var body *string
+		if review.Body != nil {
+			trimmed := strings.TrimSpace(*review.Body)
+			if trimmed != "" {
+				body = &trimmed
+			}
+		}
+
+		rep := ReportReview{
+			ID:          review.ID,
+			State:       review.State,
+			Body:        body,
+			SubmittedAt: submittedAt,
+			AuthorLogin: review.AuthorLogin,
+		}
+
+		reviewIndexByID[review.DatabaseID] = len(reportReviews)
+		reportReviews = append(reportReviews, rep)
+	}
+
+	if len(reportReviews) == 0 {
+		return Report{Reviews: []ReportReview{}}
+	}
+
+	for _, thread := range threads {
+		if filters.RequireUnresolved && thread.IsResolved {
+			continue
+		}
+		if filters.RequireNotOutdated && thread.IsOutdated {
+			continue
+		}
+
+		var parent *ThreadComment
+		replies := make([]ThreadComment, 0, len(thread.Comments))
+		for _, comment := range thread.Comments {
+			if comment.ReplyToDatabaseID == nil {
+				if parent == nil {
+					c := comment
+					parent = &c
+				}
+				continue
+			}
+			replies = append(replies, comment)
+		}
+		if parent == nil || parent.ReviewDatabaseID == nil {
+			continue
+		}
+
+		reviewIdx, ok := reviewIndexByID[*parent.ReviewDatabaseID]
+		if !ok {
+			continue
+		}
+
+		sort.SliceStable(replies, func(i, j int) bool {
+			return replies[i].CreatedAt.Before(replies[j].CreatedAt)
+		})
+
+		if filters.TailReplies > 0 && len(replies) > filters.TailReplies {
+			replies = replies[len(replies)-filters.TailReplies:]
+		}
+
+		reportReplies := make([]ThreadReply, len(replies))
+		for i, reply := range replies {
+			createdAt := reply.CreatedAt.UTC().Format(time.RFC3339)
+			reportReplies[i] = ThreadReply{
+				ID:          reply.DatabaseID,
+				InReplyToID: reply.ReplyToDatabaseID,
+				AuthorLogin: reply.AuthorLogin,
+				Body:        reply.Body,
+				CreatedAt:   createdAt,
+			}
+		}
+
+		createdAt := parent.CreatedAt.UTC().Format(time.RFC3339)
+		reportComment := ReportComment{
+			ID:          parent.DatabaseID,
+			Path:        thread.Path,
+			Line:        thread.Line,
+			AuthorLogin: parent.AuthorLogin,
+			Body:        parent.Body,
+			CreatedAt:   createdAt,
+			IsResolved:  thread.IsResolved,
+			IsOutdated:  thread.IsOutdated,
+			Thread:      reportReplies,
+		}
+
+		if len(reportReplies) == 0 {
+			reportComment.Thread = []ThreadReply{}
+		}
+
+		review := &reportReviews[reviewIdx]
+		review.Comments = append(review.Comments, reportComment)
+	}
+
+	for i := range reportReviews {
+		if len(reportReviews[i].Comments) == 0 {
+			reportReviews[i].Comments = nil
+		}
+	}
+
+	return Report{Reviews: reportReviews}
+}
+
+func allowedStateSet(states []State) map[State]struct{} {
+	if len(states) == 0 {
+		return map[State]struct{}{
+			StateApproved:         {},
+			StateChangesRequested: {},
+			StateCommented:        {},
+			StateDismissed:        {},
+		}
+	}
+
+	set := make(map[State]struct{}, len(states))
+	for _, st := range states {
+		set[st] = struct{}{}
+	}
+	return set
+}

--- a/internal/report/builder_test.go
+++ b/internal/report/builder_test.go
@@ -1,0 +1,228 @@
+package report_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Agyn-sandbox/gh-pr-review/internal/report"
+)
+
+func TestBuildReportAggregatesThreads(t *testing.T) {
+	reviewBody := "Looks good"
+	submittedAt := time.Date(2025, 12, 3, 10, 0, 0, 0, time.UTC)
+	reviews := []report.Review{
+		{
+			ID:          "R1",
+			State:       report.StateApproved,
+			Body:        &reviewBody,
+			SubmittedAt: &submittedAt,
+			AuthorLogin: "alice",
+			DatabaseID:  101,
+		},
+		{
+			ID:          "R2",
+			State:       report.StateCommented,
+			Body:        strPtr(""),
+			AuthorLogin: "bob",
+			DatabaseID:  202,
+		},
+	}
+
+	threadWithReplies := report.Thread{
+		ID:         "T1",
+		Path:       "main.go",
+		Line:       intPtr(42),
+		IsResolved: true,
+		IsOutdated: false,
+		Comments: []report.ThreadComment{
+			{
+				DatabaseID:        301,
+				Body:              "Parent comment",
+				CreatedAt:         time.Date(2025, 12, 3, 10, 1, 0, 0, time.UTC),
+				AuthorLogin:       "alice",
+				ReviewDatabaseID:  intPtr(101),
+				ReplyToDatabaseID: nil,
+			},
+			{
+				DatabaseID:        302,
+				Body:              "First reply",
+				CreatedAt:         time.Date(2025, 12, 3, 10, 2, 0, 0, time.UTC),
+				AuthorLogin:       "bob",
+				ReviewDatabaseID:  intPtr(101),
+				ReplyToDatabaseID: intPtr(301),
+			},
+			{
+				DatabaseID:        303,
+				Body:              "Second reply",
+				CreatedAt:         time.Date(2025, 12, 3, 10, 3, 0, 0, time.UTC),
+				AuthorLogin:       "alice",
+				ReviewDatabaseID:  intPtr(101),
+				ReplyToDatabaseID: intPtr(302),
+			},
+		},
+	}
+
+	threadNoReplies := report.Thread{
+		ID:         "T2",
+		Path:       "main.go",
+		Line:       nil,
+		IsResolved: true,
+		IsOutdated: false,
+		Comments: []report.ThreadComment{
+			{
+				DatabaseID:        401,
+				Body:              "Solo parent",
+				CreatedAt:         time.Date(2025, 12, 3, 10, 4, 0, 0, time.UTC),
+				AuthorLogin:       "alice",
+				ReviewDatabaseID:  intPtr(101),
+				ReplyToDatabaseID: nil,
+			},
+		},
+	}
+
+	result := report.BuildReport(reviews, []report.Thread{threadWithReplies, threadNoReplies}, report.FilterOptions{})
+
+	if len(result.Reviews) != 2 {
+		t.Fatalf("expected 2 reviews, got %d", len(result.Reviews))
+	}
+
+	first := result.Reviews[0]
+	if first.ID != "R1" {
+		t.Fatalf("expected first review to be R1, got %s", first.ID)
+	}
+	if first.SubmittedAt == nil || *first.SubmittedAt != "2025-12-03T10:00:00Z" {
+		t.Fatalf("unexpected submitted_at: %v", first.SubmittedAt)
+	}
+	if len(first.Comments) != 2 {
+		t.Fatalf("expected 2 comments for first review, got %d", len(first.Comments))
+	}
+	comment := mustFindComment(first.Comments, 301)
+	if comment.ID != 301 {
+		t.Fatalf("expected parent ID 301, got %d", comment.ID)
+	}
+	if comment.Line == nil || *comment.Line != 42 {
+		t.Fatalf("expected line 42, got %v", comment.Line)
+	}
+	if len(comment.Thread) != 2 {
+		t.Fatalf("expected 2 replies, got %d", len(comment.Thread))
+	}
+	if comment.Thread[0].ID != 302 || comment.Thread[1].ID != 303 {
+		t.Fatalf("unexpected reply IDs: %#v", comment.Thread)
+	}
+	noReplyComment := mustFindComment(first.Comments, 401)
+	if noReplyComment.ID != 401 {
+		t.Fatalf("expected parent ID 401, got %d", noReplyComment.ID)
+	}
+	if len(noReplyComment.Thread) != 0 {
+		t.Fatalf("expected no replies for comment 401, got %d", len(noReplyComment.Thread))
+	}
+
+	second := result.Reviews[1]
+	if second.Body != nil {
+		t.Fatalf("expected empty body to be omitted, got %q", *second.Body)
+	}
+	if second.SubmittedAt != nil {
+		t.Fatalf("expected submitted_at to be nil, got %v", *second.SubmittedAt)
+	}
+	if second.Comments != nil {
+		t.Fatalf("expected nil comments for second review, got %#v", second.Comments)
+	}
+
+	jsonBytes, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal report: %v", err)
+	}
+	if !strings.Contains(string(jsonBytes), `"thread":[]`) {
+		t.Fatal("expected empty thread array encoded")
+	}
+	if strings.Contains(string(jsonBytes), `"body":""`) {
+		t.Fatal("expected empty body fields to be omitted from JSON")
+	}
+}
+
+func TestBuildReportFilterOptions(t *testing.T) {
+	reviews := []report.Review{
+		{ID: "R1", State: report.StateApproved, AuthorLogin: "alice", DatabaseID: 1},
+		{ID: "R2", State: report.StateChangesRequested, AuthorLogin: "bob", DatabaseID: 2},
+	}
+
+	threads := []report.Thread{
+		{
+			ID:         "T1",
+			Path:       "file.go",
+			IsResolved: false,
+			IsOutdated: true,
+			Comments: []report.ThreadComment{
+				{DatabaseID: 10, Body: "Parent", CreatedAt: time.Date(2025, 12, 3, 0, 0, 0, 0, time.UTC), AuthorLogin: "alice", ReviewDatabaseID: intPtr(1)},
+				{DatabaseID: 11, Body: "Reply", CreatedAt: time.Date(2025, 12, 3, 0, 1, 0, 0, time.UTC), AuthorLogin: "carol", ReviewDatabaseID: intPtr(1), ReplyToDatabaseID: intPtr(10)},
+			},
+		},
+		{
+			ID:         "T2",
+			Path:       "file.go",
+			IsResolved: false,
+			IsOutdated: false,
+			Comments: []report.ThreadComment{
+				{DatabaseID: 20, Body: "Parent", CreatedAt: time.Date(2025, 12, 3, 0, 2, 0, 0, time.UTC), AuthorLogin: "bob", ReviewDatabaseID: intPtr(2)},
+				{DatabaseID: 21, Body: "Reply1", CreatedAt: time.Date(2025, 12, 3, 0, 3, 0, 0, time.UTC), AuthorLogin: "dave", ReviewDatabaseID: intPtr(2), ReplyToDatabaseID: intPtr(20)},
+				{DatabaseID: 22, Body: "Reply2", CreatedAt: time.Date(2025, 12, 3, 0, 4, 0, 0, time.UTC), AuthorLogin: "eve", ReviewDatabaseID: intPtr(2), ReplyToDatabaseID: intPtr(21)},
+			},
+		},
+	}
+
+	filters := report.FilterOptions{
+		Reviewer:           "bob",
+		States:             []report.State{report.StateChangesRequested},
+		RequireUnresolved:  true,
+		RequireNotOutdated: true,
+		TailReplies:        1,
+	}
+
+	result := report.BuildReport(reviews, threads, filters)
+
+	if len(result.Reviews) != 1 {
+		t.Fatalf("expected 1 review, got %d", len(result.Reviews))
+	}
+	review := result.Reviews[0]
+	if review.ID != "R2" {
+		t.Fatalf("expected review R2, got %s", review.ID)
+	}
+	if len(review.Comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(review.Comments))
+	}
+	comment := review.Comments[0]
+	if comment.ID != 20 {
+		t.Fatalf("expected parent ID 20, got %d", comment.ID)
+	}
+	if len(comment.Thread) != 1 {
+		t.Fatalf("expected 1 reply after tail filter, got %d", len(comment.Thread))
+	}
+	if comment.Thread[0].ID != 22 {
+		t.Fatalf("expected last reply ID 22, got %d", comment.Thread[0].ID)
+	}
+	if comment.IsOutdated {
+		t.Fatal("expected is_outdated to be false after filtering")
+	}
+	if comment.IsResolved {
+		t.Fatal("expected unresolved thread to remain unresolved")
+	}
+}
+
+func intPtr(v int) *int {
+	return &v
+}
+
+func mustFindComment(comments []report.ReportComment, id int) report.ReportComment {
+	for _, comment := range comments {
+		if comment.ID == id {
+			return comment
+		}
+	}
+	return report.ReportComment{}
+}
+
+func strPtr(v string) *string {
+	return &v
+}

--- a/internal/report/domain.go
+++ b/internal/report/domain.go
@@ -1,0 +1,89 @@
+package report
+
+import "time"
+
+// State represents the pull request review state supported by the report command.
+type State string
+
+const (
+	StateApproved         State = "APPROVED"
+	StateChangesRequested State = "CHANGES_REQUESTED"
+	StateCommented        State = "COMMENTED"
+	StateDismissed        State = "DISMISSED"
+)
+
+// FilterOptions controls shaping of reviews and threads.
+type FilterOptions struct {
+	Reviewer           string
+	States             []State
+	RequireUnresolved  bool
+	RequireNotOutdated bool
+	TailReplies        int
+}
+
+// Review models a pull request review fetched from GraphQL.
+type Review struct {
+	ID          string
+	State       State
+	Body        *string
+	SubmittedAt *time.Time
+	AuthorLogin string
+	DatabaseID  int
+}
+
+// Thread captures a review thread and its constituent comments.
+type Thread struct {
+	ID         string
+	Path       string
+	Line       *int
+	IsResolved bool
+	IsOutdated bool
+	Comments   []ThreadComment
+}
+
+// ThreadComment represents a single comment node within a thread.
+type ThreadComment struct {
+	DatabaseID        int
+	Body              string
+	CreatedAt         time.Time
+	AuthorLogin       string
+	ReviewDatabaseID  *int
+	ReplyToDatabaseID *int
+}
+
+// Report is the serialized output structure for the report command.
+type Report struct {
+	Reviews []ReportReview `json:"reviews"`
+}
+
+// ReportReview aggregates review data and associated thread comments.
+type ReportReview struct {
+	ID          string          `json:"id"`
+	State       State           `json:"state"`
+	Body        *string         `json:"body,omitempty"`
+	SubmittedAt *string         `json:"submitted_at,omitempty"`
+	AuthorLogin string          `json:"author_login"`
+	Comments    []ReportComment `json:"comments,omitempty"`
+}
+
+// ReportComment contains the shaped parent comment for a thread.
+type ReportComment struct {
+	ID          int           `json:"id"`
+	Path        string        `json:"path"`
+	Line        *int          `json:"line,omitempty"`
+	AuthorLogin string        `json:"author_login"`
+	Body        string        `json:"body"`
+	CreatedAt   string        `json:"created_at"`
+	IsResolved  bool          `json:"is_resolved"`
+	IsOutdated  bool          `json:"is_outdated"`
+	Thread      []ThreadReply `json:"thread"`
+}
+
+// ThreadReply captures a reply within a thread.
+type ThreadReply struct {
+	ID          int    `json:"id"`
+	InReplyToID *int   `json:"in_reply_to_id,omitempty"`
+	AuthorLogin string `json:"author_login"`
+	Body        string `json:"body"`
+	CreatedAt   string `json:"created_at"`
+}

--- a/internal/report/query.go
+++ b/internal/report/query.go
@@ -1,0 +1,51 @@
+package report
+
+const reportQuery = `query Report(
+  $owner: String!,
+  $name: String!,
+  $number: Int!,
+  $states: [PullRequestReviewState!],
+  $firstReviews: Int,
+  $firstThreads: Int,
+  $firstComments: Int
+) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviews(first: $firstReviews, states: $states) {
+        nodes {
+          id
+          state
+          body
+          submittedAt
+          databaseId
+          author { login }
+        }
+      }
+      reviewThreads(first: $firstThreads) {
+        nodes {
+          id
+          path
+          line
+          isResolved
+          isOutdated
+          comments(first: $firstComments) {
+            nodes {
+              databaseId
+              body
+              createdAt
+              author { login }
+              pullRequestReview {
+                id
+                state
+                databaseId
+              }
+              replyTo {
+                databaseId
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`

--- a/internal/report/service.go
+++ b/internal/report/service.go
@@ -1,0 +1,208 @@
+package report
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Agyn-sandbox/gh-pr-review/internal/ghcli"
+	"github.com/Agyn-sandbox/gh-pr-review/internal/resolver"
+)
+
+const (
+	defaultFirstReviews  = 100
+	defaultFirstThreads  = 100
+	defaultFirstComments = 100
+)
+
+// Service fetches and shapes pull request review reports.
+type Service struct {
+	API ghcli.API
+}
+
+// Options controls data retrieval and shaping for the report.
+type Options struct {
+	Reviewer           string
+	States             []State
+	StatesProvided     bool
+	RequireUnresolved  bool
+	RequireNotOutdated bool
+	TailReplies        int
+}
+
+// NewService constructs a report service using the provided GraphQL API client.
+func NewService(api ghcli.API) *Service {
+	return &Service{API: api}
+}
+
+// Fetch generates a review report for the given pull request.
+func (s *Service) Fetch(pr resolver.Identity, opts Options) (Report, error) {
+	variables := map[string]interface{}{
+		"owner":         pr.Owner,
+		"name":          pr.Repo,
+		"number":        pr.Number,
+		"firstReviews":  defaultFirstReviews,
+		"firstThreads":  defaultFirstThreads,
+		"firstComments": defaultFirstComments,
+	}
+	if opts.StatesProvided {
+		states := make([]string, len(opts.States))
+		for i, st := range opts.States {
+			states[i] = string(st)
+		}
+		variables["states"] = states
+	}
+
+	var response struct {
+		Repository *struct {
+			PullRequest *struct {
+				Reviews struct {
+					Nodes []struct {
+						ID          string  `json:"id"`
+						State       string  `json:"state"`
+						Body        *string `json:"body"`
+						SubmittedAt *string `json:"submittedAt"`
+						DatabaseID  *int    `json:"databaseId"`
+						Author      *struct {
+							Login string `json:"login"`
+						} `json:"author"`
+					} `json:"nodes"`
+				} `json:"reviews"`
+				ReviewThreads struct {
+					Nodes []struct {
+						ID         string `json:"id"`
+						Path       string `json:"path"`
+						Line       *int   `json:"line"`
+						IsResolved bool   `json:"isResolved"`
+						IsOutdated bool   `json:"isOutdated"`
+						Comments   struct {
+							Nodes []struct {
+								DatabaseID int    `json:"databaseId"`
+								Body       string `json:"body"`
+								CreatedAt  string `json:"createdAt"`
+								Author     *struct {
+									Login string `json:"login"`
+								} `json:"author"`
+								PullRequestReview *struct {
+									DatabaseID *int   `json:"databaseId"`
+									State      string `json:"state"`
+									ID         string `json:"id"`
+								} `json:"pullRequestReview"`
+								ReplyTo *struct {
+									DatabaseID int `json:"databaseId"`
+								} `json:"replyTo"`
+							} `json:"nodes"`
+						} `json:"comments"`
+					} `json:"nodes"`
+				} `json:"reviewThreads"`
+			} `json:"pullRequest"`
+		} `json:"repository"`
+	}
+
+	if err := s.API.GraphQL(reportQuery, variables, &response); err != nil {
+		return Report{}, err
+	}
+
+	if response.Repository == nil || response.Repository.PullRequest == nil {
+		return Report{}, errors.New("pull request not found or inaccessible")
+	}
+
+	prData := response.Repository.PullRequest
+	reviews := make([]Review, 0, len(prData.Reviews.Nodes))
+
+	for _, node := range prData.Reviews.Nodes {
+		if node.DatabaseID == nil {
+			return Report{}, errors.New("review missing databaseId")
+		}
+		if node.Author == nil || node.Author.Login == "" {
+			return Report{}, errors.New("review missing author login")
+		}
+		state, ok := parseState(node.State)
+		if !ok {
+			return Report{}, fmt.Errorf("unknown review state %q", node.State)
+		}
+		review := Review{
+			ID:          node.ID,
+			State:       state,
+			Body:        node.Body,
+			AuthorLogin: node.Author.Login,
+			DatabaseID:  *node.DatabaseID,
+		}
+		if node.SubmittedAt != nil && strings.TrimSpace(*node.SubmittedAt) != "" {
+			parsed, err := time.Parse(time.RFC3339, *node.SubmittedAt)
+			if err != nil {
+				return Report{}, fmt.Errorf("parse review submittedAt: %w", err)
+			}
+			review.SubmittedAt = &parsed
+		}
+		reviews = append(reviews, review)
+	}
+
+	threads := make([]Thread, 0, len(prData.ReviewThreads.Nodes))
+	for _, node := range prData.ReviewThreads.Nodes {
+		thread := Thread{
+			ID:         node.ID,
+			Path:       node.Path,
+			Line:       node.Line,
+			IsResolved: node.IsResolved,
+			IsOutdated: node.IsOutdated,
+			Comments:   make([]ThreadComment, 0, len(node.Comments.Nodes)),
+		}
+
+		for _, comment := range node.Comments.Nodes {
+			if comment.Author == nil || comment.Author.Login == "" {
+				return Report{}, errors.New("comment missing author login")
+			}
+			createdAt, err := time.Parse(time.RFC3339, comment.CreatedAt)
+			if err != nil {
+				return Report{}, fmt.Errorf("parse comment createdAt: %w", err)
+			}
+			var reviewDatabaseID *int
+			if comment.PullRequestReview != nil {
+				reviewDatabaseID = comment.PullRequestReview.DatabaseID
+			}
+			var replyTo *int
+			if comment.ReplyTo != nil {
+				replyID := comment.ReplyTo.DatabaseID
+				replyTo = &replyID
+			}
+
+			thread.Comments = append(thread.Comments, ThreadComment{
+				DatabaseID:        comment.DatabaseID,
+				Body:              comment.Body,
+				CreatedAt:         createdAt,
+				AuthorLogin:       comment.Author.Login,
+				ReviewDatabaseID:  reviewDatabaseID,
+				ReplyToDatabaseID: replyTo,
+			})
+		}
+
+		threads = append(threads, thread)
+	}
+
+	filters := FilterOptions{
+		Reviewer:           opts.Reviewer,
+		States:             opts.States,
+		RequireUnresolved:  opts.RequireUnresolved,
+		RequireNotOutdated: opts.RequireNotOutdated,
+		TailReplies:        opts.TailReplies,
+	}
+
+	return BuildReport(reviews, threads, filters), nil
+}
+
+func parseState(raw string) (State, bool) {
+	switch strings.ToUpper(strings.TrimSpace(raw)) {
+	case string(StateApproved):
+		return StateApproved, true
+	case string(StateChangesRequested):
+		return StateChangesRequested, true
+	case string(StateCommented):
+		return StateCommented, true
+	case string(StateDismissed):
+		return StateDismissed, true
+	default:
+		return "", false
+	}
+}

--- a/internal/report/service_test.go
+++ b/internal/report/service_test.go
@@ -1,0 +1,111 @@
+package report
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	_ "embed"
+
+	"github.com/Agyn-sandbox/gh-pr-review/internal/resolver"
+)
+
+//go:embed testdata/report_response.json
+var reportResponseFixture []byte
+
+func TestServiceFetchShapesReport(t *testing.T) {
+	fake := &stubAPI{t: t, payload: reportResponseFixture}
+	svc := NewService(fake)
+
+	identity := resolver.Identity{Owner: "agyn", Repo: "sandbox", Number: 51}
+	result, err := svc.Fetch(identity, Options{
+		Reviewer:           "alice",
+		States:             []State{StateApproved, StateCommented},
+		StatesProvided:     true,
+		RequireNotOutdated: true,
+		TailReplies:        1,
+	})
+	if err != nil {
+		t.Fatalf("fetch report: %v", err)
+	}
+
+	if len(result.Reviews) != 1 {
+		t.Fatalf("expected 1 review after filtering, got %d", len(result.Reviews))
+	}
+	review := result.Reviews[0]
+	if review.ID != "R1" {
+		t.Fatalf("expected review R1, got %s", review.ID)
+	}
+	if len(review.Comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(review.Comments))
+	}
+	comment := review.Comments[0]
+	if comment.ID != 301 {
+		t.Fatalf("expected parent comment 301, got %d", comment.ID)
+	}
+	if len(comment.Thread) != 1 {
+		t.Fatalf("expected 1 reply after tail filter, got %d", len(comment.Thread))
+	}
+	if comment.Thread[0].ID != 303 {
+		t.Fatalf("expected reply 303, got %d", comment.Thread[0].ID)
+	}
+
+	rawStates, ok := fake.lastVariables["states"]
+	if !ok {
+		t.Fatalf("expected states variable propagated, variables: %#v", fake.lastVariables)
+	}
+	statesVar, ok := rawStates.([]string)
+	if !ok || len(statesVar) != 2 {
+		t.Fatalf("expected states variable propagated as []string, got %#v", rawStates)
+	}
+}
+
+func TestServiceFetchErrorsOnMissingReviewDBID(t *testing.T) {
+	broken := map[string]any{}
+	if err := json.Unmarshal(reportResponseFixture, &broken); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+	repo := broken["repository"].(map[string]any)
+	pr := repo["pullRequest"].(map[string]any)
+	reviews := pr["reviews"].(map[string]any)
+	nodes := reviews["nodes"].([]any)
+	first := nodes[0].(map[string]any)
+	delete(first, "databaseId")
+
+	modified, err := json.Marshal(broken)
+	if err != nil {
+		t.Fatalf("marshal modified: %v", err)
+	}
+
+	fake := &stubAPI{t: t, payload: modified}
+	svc := NewService(fake)
+
+	_, err = svc.Fetch(resolver.Identity{Owner: "agyn", Repo: "sandbox", Number: 51}, Options{})
+	if err == nil {
+		t.Fatal("expected error for missing databaseId")
+	}
+	if !strings.Contains(err.Error(), "review missing databaseId") {
+		t.Fatalf("expected missing databaseId error, got %v", err)
+	}
+}
+
+type stubAPI struct {
+	t             *testing.T
+	payload       []byte
+	lastQuery     string
+	lastVariables map[string]interface{}
+}
+
+func (s *stubAPI) REST(string, string, map[string]string, interface{}, interface{}) error {
+	s.t.Fatalf("unexpected REST call in report service test")
+	return nil
+}
+
+func (s *stubAPI) GraphQL(query string, variables map[string]interface{}, result interface{}) error {
+	s.lastQuery = query
+	s.lastVariables = variables
+	if query != reportQuery {
+		s.t.Fatalf("unexpected query: %s", query)
+	}
+	return json.Unmarshal(s.payload, result)
+}

--- a/internal/report/testdata/report_response.json
+++ b/internal/report/testdata/report_response.json
@@ -1,0 +1,112 @@
+{
+  "repository": {
+    "pullRequest": {
+      "reviews": {
+        "nodes": [
+          {
+            "id": "R1",
+            "state": "APPROVED",
+            "body": "Looks good overall",
+            "submittedAt": "2025-12-03T10:00:00Z",
+            "databaseId": 101,
+            "author": { "login": "alice" }
+          },
+          {
+            "id": "R2",
+            "state": "COMMENTED",
+            "body": "",
+            "submittedAt": null,
+            "databaseId": 202,
+            "author": { "login": "bob" }
+          }
+        ]
+      },
+      "reviewThreads": {
+        "nodes": [
+          {
+            "id": "T1",
+            "path": "main.go",
+            "line": 42,
+            "isResolved": false,
+            "isOutdated": false,
+            "comments": {
+              "nodes": [
+                {
+                  "databaseId": 301,
+                  "body": "Parent comment 1",
+                  "createdAt": "2025-12-03T10:01:00Z",
+                  "author": { "login": "alice" },
+                  "pullRequestReview": {
+                    "id": "R1",
+                    "state": "APPROVED",
+                    "databaseId": 101
+                  },
+                  "replyTo": null
+                },
+                {
+                  "databaseId": 302,
+                  "body": "Reply alpha",
+                  "createdAt": "2025-12-03T10:02:00Z",
+                  "author": { "login": "bob" },
+                  "pullRequestReview": {
+                    "id": "R1",
+                    "state": "APPROVED",
+                    "databaseId": 101
+                  },
+                  "replyTo": { "databaseId": 301 }
+                },
+                {
+                  "databaseId": 303,
+                  "body": "Reply beta",
+                  "createdAt": "2025-12-03T10:03:00Z",
+                  "author": { "login": "alice" },
+                  "pullRequestReview": {
+                    "id": "R1",
+                    "state": "APPROVED",
+                    "databaseId": 101
+                  },
+                  "replyTo": { "databaseId": 302 }
+                }
+              ]
+            }
+          },
+          {
+            "id": "T2",
+            "path": "main.go",
+            "line": null,
+            "isResolved": true,
+            "isOutdated": true,
+            "comments": {
+              "nodes": [
+                {
+                  "databaseId": 401,
+                  "body": "Parent comment 2",
+                  "createdAt": "2025-12-03T10:04:00Z",
+                  "author": { "login": "bob" },
+                  "pullRequestReview": {
+                    "id": "R2",
+                    "state": "COMMENTED",
+                    "databaseId": 202
+                  },
+                  "replyTo": null
+                },
+                {
+                  "databaseId": 402,
+                  "body": "Reply gamma",
+                  "createdAt": "2025-12-03T10:05:00Z",
+                  "author": { "login": "alice" },
+                  "pullRequestReview": {
+                    "id": "R2",
+                    "state": "COMMENTED",
+                    "databaseId": 202
+                  },
+                  "replyTo": { "databaseId": 401 }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add GraphQL-backed `gh pr-review review report` command with filtering flags
- shape review/thread payload into stable JSON without nulls and add service/builder coverage
- document engineer and MCP quick references for the new report workflow

## Testing
- CGO_ENABLED=0 go test ./...
- CGO_ENABLED=0 golangci-lint run
- CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o /tmp/gh-pr-review ./cmd

Resolves #51.
