### PR TITLE
chore: add linux arm64 release target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,3 +16,9 @@ jobs:
       - uses: cli/gh-extension-precompile@v2
         with:
           go_version_file: go.mod
+          targets: |
+            macOS-amd64
+            macOS-arm64
+            linux-amd64
+            linux-arm64
+            windows-amd64


### PR DESCRIPTION
## Summary
- update the release workflow to build precompiled linux-arm64 artifacts alongside the existing targets

## Testing
- n/a (workflow-only change)
