### PR TITLE
docs: expand review report usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ gh extension upgrade Agyn-sandbox/gh-pr-review
 | `--states <list>` | Comma-separated review states (`APPROVED`, `CHANGES_REQUESTED`, `COMMENTED`, `DISMISSED`). |
 | `--unresolved` | Keep only unresolved threads. |
 | `--not_outdated` | Exclude threads marked as outdated. |
-| `--tail <n>` | Retain only the last `n` replies per thread (0 = all). |
+| `--tail <n>` | Retain only the last `n` replies per thread (0 = all). The parent inline comment is always kept; only replies are trimmed. |
 
 ### Examples
 


### PR DESCRIPTION
## Summary
- add README coverage for `gh pr-review review report`, including command behavior, filters, and examples
- highlight linux-arm64 availability starting in v1.3.3 and cross-link reply-by-id workflow
- document backend and JSON design notes for headless/LLM consumers

## Testing
- CGO_ENABLED=0 go test ./...
- CGO_ENABLED=0 golangci-lint run

Resolves #54.
