### PR TITLE
feat: remove database_id from review --start

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,16 @@ The quickest path from opening a pending review to resolving threads:
    > existing macOS, Windows, and Linux targets.
 
 2. **Start a pending review (GraphQL).** Capture the returned `id` (GraphQL
-   node) and optional `database_id`.
+   node).
 
    ```sh
    gh pr-review review --start owner/repo#42
 
-   {
-     "id": "PRR_kwDOAAABbcdEFG12",
-     "state": "PENDING",
-     "database_id": 3531807471,
-     "html_url": "https://github.com/owner/repo/pull/42#pullrequestreview-3531807471"
-   }
+{
+  "id": "PRR_kwDOAAABbcdEFG12",
+  "state": "PENDING",
+  "html_url": "https://github.com/owner/repo/pull/42#pullrequestreview-3531807471"
+}
    ```
 
 3. **Add inline comments with the pending review ID (GraphQL).** The

--- a/cmd/review_test.go
+++ b/cmd/review_test.go
@@ -36,10 +36,9 @@ func TestReviewStartCommand_GraphQLOnly(t *testing.T) {
 			payload := map[string]interface{}{
 				"addPullRequestReview": map[string]interface{}{
 					"pullRequestReview": map[string]interface{}{
-						"id":         "PRR_review",
-						"state":      "PENDING",
-						"databaseId": float64(88),
-						"url":        "https://example.com/review/PRR_review",
+						"id":    "PRR_review",
+						"state": "PENDING",
+						"url":   "https://example.com/review/PRR_review",
 					},
 				},
 			}
@@ -65,10 +64,11 @@ func TestReviewStartCommand_GraphQLOnly(t *testing.T) {
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &payload))
 	assert.Equal(t, "PRR_review", payload["id"])
 	assert.Equal(t, "PENDING", payload["state"])
-	assert.Equal(t, float64(88), payload["database_id"])
 	assert.Equal(t, "https://example.com/review/PRR_review", payload["html_url"])
 	_, hasSubmitted := payload["submitted_at"]
 	assert.False(t, hasSubmitted)
+	_, hasDatabase := payload["database_id"]
+	assert.False(t, hasDatabase)
 	assert.Equal(t, 2, call)
 }
 

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -27,11 +27,6 @@ Used by `review --start` and `review --submit`.
       "format": "date-time",
       "description": "RFC3339 timestamp of the submission (omitted when pending)"
     },
-    "database_id": {
-      "type": "integer",
-      "minimum": 1,
-      "description": "REST review identifier"
-    },
     "html_url": {
       "type": "string",
       "format": "uri",

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -19,7 +19,7 @@ instead of serializing as `null`. Array responses default to `[]`.
     the pull request head).
 - **Backend:** GitHub GraphQL `addPullRequestReview` mutation.
 - **Output schema:** [`ReviewState`](SCHEMAS.md#reviewstate) — required fields
-  `id` and `state`; optional `submitted_at`, `database_id`, `html_url`.
+  `id` and `state`; optional `submitted_at`, `html_url`.
 
 ```sh
 gh pr-review review --start owner/repo#42
@@ -27,7 +27,6 @@ gh pr-review review --start owner/repo#42
 {
   "id": "PRR_kwDOAAABbcdEFG12",
   "state": "PENDING",
-  "database_id": 3531807471,
   "html_url": "https://github.com/owner/repo/pull/42#pullrequestreview-3531807471"
 }
 ```

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -22,7 +22,6 @@ type ReviewState struct {
 	ID          string  `json:"id"`
 	State       string  `json:"state"`
 	SubmittedAt *string `json:"submitted_at,omitempty"`
-	DatabaseID  *int64  `json:"database_id,omitempty"`
 	HTMLURL     *string `json:"html_url,omitempty"`
 }
 
@@ -77,7 +76,7 @@ func (s *Service) Start(pr resolver.Identity, commitOID string) (*ReviewState, e
 
 	const mutation = `mutation($input:AddPullRequestReviewInput!){
   addPullRequestReview(input:$input){
-    pullRequestReview { id state submittedAt databaseId url }
+    pullRequestReview { id state submittedAt url }
   }
 }`
 
@@ -94,7 +93,6 @@ func (s *Service) Start(pr resolver.Identity, commitOID string) (*ReviewState, e
 				ID          string  `json:"id"`
 				State       string  `json:"state"`
 				SubmittedAt *string `json:"submittedAt"`
-				DatabaseID  *int64  `json:"databaseId"`
 				URL         string  `json:"url"`
 			} `json:"pullRequestReview"`
 		} `json:"addPullRequestReview"`
@@ -125,9 +123,6 @@ func (s *Service) Start(pr resolver.Identity, commitOID string) (*ReviewState, e
 		if trimmed != "" {
 			state.SubmittedAt = &trimmed
 		}
-	}
-	if prr.DatabaseID != nil {
-		state.DatabaseID = prr.DatabaseID
 	}
 	state.HTMLURL = &trimmedURL
 

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -62,7 +62,6 @@ func TestServiceStart(t *testing.T) {
 						"id":          "PRR_review",
 						"state":       "PENDING",
 						"submittedAt": nil,
-						"databaseId":  321,
 						"url":         "https://example.com/review/PRR_review",
 					},
 				},
@@ -79,8 +78,6 @@ func TestServiceStart(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "PRR_review", state.ID)
 	assert.Equal(t, "PENDING", state.State)
-	require.NotNil(t, state.DatabaseID)
-	assert.Equal(t, int64(321), *state.DatabaseID)
 	require.Nil(t, state.SubmittedAt)
 	require.NotNil(t, state.HTMLURL)
 	assert.Equal(t, "https://example.com/review/PRR_review", *state.HTMLURL)


### PR DESCRIPTION
## Summary
- stop including `database_id` in `review --start` responses
- align README/USAGE/SCHEMAS docs and CLI tests with the new shape
- ensure coverage that the payload only exposes the expected fields

## Testing
- CGO_ENABLED=0 go test ./...
- CGO_ENABLED=0 golangci-lint run

## Migration Notes
- Clients relying on `database_id` from `review --start` must switch to other APIs (breaking change).

Fixes #60
