### PR TITLE
feat: remove html_url from review --start

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ The quickest path from opening a pending review to resolving threads:
 
 {
   "id": "PRR_kwDOAAABbcdEFG12",
-  "state": "PENDING",
-  "html_url": "https://github.com/owner/repo/pull/42#pullrequestreview-3531807471"
+  "state": "PENDING"
 }
    ```
+
+   Pending reviews omit `submitted_at`; the field appears after submission.
 
 3. **Add inline comments with the pending review ID (GraphQL).** The
    `review --add-comment` command fails fast if you supply a numeric ID instead

--- a/cmd/review_test.go
+++ b/cmd/review_test.go
@@ -38,7 +38,6 @@ func TestReviewStartCommand_GraphQLOnly(t *testing.T) {
 					"pullRequestReview": map[string]interface{}{
 						"id":    "PRR_review",
 						"state": "PENDING",
-						"url":   "https://example.com/review/PRR_review",
 					},
 				},
 			}
@@ -64,9 +63,10 @@ func TestReviewStartCommand_GraphQLOnly(t *testing.T) {
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &payload))
 	assert.Equal(t, "PRR_review", payload["id"])
 	assert.Equal(t, "PENDING", payload["state"])
-	assert.Equal(t, "https://example.com/review/PRR_review", payload["html_url"])
 	_, hasSubmitted := payload["submitted_at"]
 	assert.False(t, hasSubmitted)
+	_, hasHTML := payload["html_url"]
+	assert.False(t, hasHTML)
 	_, hasDatabase := payload["database_id"]
 	assert.False(t, hasDatabase)
 	assert.Equal(t, 2, call)

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -26,11 +26,6 @@ Used by `review --start` and `review --submit`.
       "type": "string",
       "format": "date-time",
       "description": "RFC3339 timestamp of the submission (omitted when pending)"
-    },
-    "html_url": {
-      "type": "string",
-      "format": "uri",
-      "description": "Link to the review on GitHub"
     }
   },
   "additionalProperties": false

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -19,15 +19,14 @@ instead of serializing as `null`. Array responses default to `[]`.
     the pull request head).
 - **Backend:** GitHub GraphQL `addPullRequestReview` mutation.
 - **Output schema:** [`ReviewState`](SCHEMAS.md#reviewstate) — required fields
-  `id` and `state`; optional `submitted_at`, `html_url`.
+  `id` and `state`; optional `submitted_at`.
 
 ```sh
 gh pr-review review --start owner/repo#42
 
 {
   "id": "PRR_kwDOAAABbcdEFG12",
-  "state": "PENDING",
-  "html_url": "https://github.com/owner/repo/pull/42#pullrequestreview-3531807471"
+  "state": "PENDING"
 }
 ```
 

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -22,7 +22,6 @@ type ReviewState struct {
 	ID          string  `json:"id"`
 	State       string  `json:"state"`
 	SubmittedAt *string `json:"submitted_at,omitempty"`
-	HTMLURL     *string `json:"html_url,omitempty"`
 }
 
 // SubmitStatus represents the outcome of a review submission mutation.
@@ -76,7 +75,7 @@ func (s *Service) Start(pr resolver.Identity, commitOID string) (*ReviewState, e
 
 	const mutation = `mutation($input:AddPullRequestReviewInput!){
   addPullRequestReview(input:$input){
-    pullRequestReview { id state submittedAt url }
+    pullRequestReview { id state submittedAt }
   }
 }`
 
@@ -93,7 +92,6 @@ func (s *Service) Start(pr resolver.Identity, commitOID string) (*ReviewState, e
 				ID          string  `json:"id"`
 				State       string  `json:"state"`
 				SubmittedAt *string `json:"submittedAt"`
-				URL         string  `json:"url"`
 			} `json:"pullRequestReview"`
 		} `json:"addPullRequestReview"`
 	}
@@ -111,11 +109,6 @@ func (s *Service) Start(pr resolver.Identity, commitOID string) (*ReviewState, e
 	if trimmedState == "" {
 		return nil, errors.New("addPullRequestReview returned empty state")
 	}
-	trimmedURL := strings.TrimSpace(prr.URL)
-	if trimmedURL == "" {
-		return nil, errors.New("addPullRequestReview returned empty url")
-	}
-
 	state := ReviewState{ID: trimmedID, State: trimmedState}
 
 	if prr.SubmittedAt != nil {
@@ -124,7 +117,6 @@ func (s *Service) Start(pr resolver.Identity, commitOID string) (*ReviewState, e
 			state.SubmittedAt = &trimmed
 		}
 	}
-	state.HTMLURL = &trimmedURL
 
 	return &state, nil
 }


### PR DESCRIPTION
## Summary
- remove `html_url` from `review --start` ReviewState responses and schema
- update CLI tests to assert only `id`, `state`, and optional `submitted_at`
- refresh README/USAGE docs to describe the trimmed payload

## Testing
- CGO_ENABLED=0 go test ./...
- CGO_ENABLED=0 golangci-lint run

## Migration Notes
- Clients using `html_url` from `review --start` must derive review URLs through other APIs (breaking change).

Fixes #60
