### PR TITLE
feat: adopt graphql replies and ids

### DIFF
--- a/cmd/review_report.go
+++ b/cmd/review_report.go
@@ -34,19 +34,21 @@ func newReviewReportCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.Unresolved, "unresolved", false, "Only include unresolved threads")
 	cmd.Flags().BoolVar(&opts.NotOutdated, "not_outdated", false, "Exclude outdated threads")
 	cmd.Flags().IntVar(&opts.TailReplies, "tail", 0, "Limit to the last N replies per thread (0 = all)")
+	cmd.Flags().BoolVar(&opts.IncludeCommentNodeID, "include-comment-node-id", false, "Include comment_node_id fields for parent comments and replies")
 
 	return cmd
 }
 
 type reviewReportOptions struct {
-	Repo        string
-	Pull        int
-	Selector    string
-	Reviewer    string
-	States      []string
-	Unresolved  bool
-	NotOutdated bool
-	TailReplies int
+	Repo                 string
+	Pull                 int
+	Selector             string
+	Reviewer             string
+	States               []string
+	Unresolved           bool
+	NotOutdated          bool
+	TailReplies          int
+	IncludeCommentNodeID bool
 }
 
 func runReviewReport(cmd *cobra.Command, opts *reviewReportOptions) error {
@@ -71,12 +73,13 @@ func runReviewReport(cmd *cobra.Command, opts *reviewReportOptions) error {
 
 	service := report.NewService(apiClientFactory(identity.Host))
 	output, err := service.Fetch(identity, report.Options{
-		Reviewer:           strings.TrimSpace(opts.Reviewer),
-		States:             states,
-		StatesProvided:     statesProvided,
-		RequireUnresolved:  opts.Unresolved,
-		RequireNotOutdated: opts.NotOutdated,
-		TailReplies:        opts.TailReplies,
+		Reviewer:             strings.TrimSpace(opts.Reviewer),
+		States:               states,
+		StatesProvided:       statesProvided,
+		RequireUnresolved:    opts.Unresolved,
+		RequireNotOutdated:   opts.NotOutdated,
+		TailReplies:          opts.TailReplies,
+		IncludeCommentNodeID: opts.IncludeCommentNodeID,
 	})
 	if err != nil {
 		return err

--- a/cmd/review_report_test.go
+++ b/cmd/review_report_test.go
@@ -42,9 +42,11 @@ func TestReviewReportCommandFiltersOutput(t *testing.T) {
 			ID       string  `json:"id"`
 			Body     *string `json:"body"`
 			Comments []struct {
-				ID     int `json:"id"`
-				Thread []struct {
-					ID int `json:"id"`
+				ThreadID      string  `json:"thread_id"`
+				CommentNodeID *string `json:"comment_node_id"`
+				Thread        []struct {
+					Body          string  `json:"body"`
+					CommentNodeID *string `json:"comment_node_id"`
 				} `json:"thread"`
 			} `json:"comments"`
 		} `json:"reviews"`
@@ -65,11 +67,21 @@ func TestReviewReportCommandFiltersOutput(t *testing.T) {
 	if len(review.Comments) != 1 {
 		t.Fatalf("expected 1 comment for R1, got %d", len(review.Comments))
 	}
-	if len(review.Comments[0].Thread) != 1 {
-		t.Fatalf("expected 1 reply after tail filter, got %d", len(review.Comments[0].Thread))
+	comment := review.Comments[0]
+	if comment.ThreadID == "" {
+		t.Fatal("expected thread_id to be present")
 	}
-	if review.Comments[0].Thread[0].ID != 303 {
-		t.Fatalf("expected reply id 303, got %d", review.Comments[0].Thread[0].ID)
+	if comment.CommentNodeID != nil {
+		t.Fatalf("expected comment_node_id omitted by default, got %v", *comment.CommentNodeID)
+	}
+	if len(comment.Thread) != 1 {
+		t.Fatalf("expected 1 reply after tail filter, got %d", len(comment.Thread))
+	}
+	if comment.Thread[0].Body != "Reply beta" {
+		t.Fatalf("expected last reply body 'Reply beta', got %s", comment.Thread[0].Body)
+	}
+	if comment.Thread[0].CommentNodeID != nil {
+		t.Fatalf("expected reply comment_node_id omitted by default, got %v", *comment.Thread[0].CommentNodeID)
 	}
 
 	rawStates, ok := fake.variables["states"].([]string)
@@ -90,6 +102,50 @@ func TestReviewReportCommandInvalidState(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "invalid review state") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestReviewReportCommandIncludesCommentNodeID(t *testing.T) {
+	originalFactory := apiClientFactory
+	defer func() { apiClientFactory = originalFactory }()
+
+	fake := &fakeReportAPI{payload: reportResponse, t: t}
+	apiClientFactory = func(host string) ghcli.API { return fake }
+
+	root := newRootCommand()
+	buf := &bytes.Buffer{}
+	root.SetOut(buf)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{"review", "report", "agyn/repo#51", "--include-comment-node-id"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute command: %v", err)
+	}
+
+	var payload struct {
+		Reviews []struct {
+			Comments []struct {
+				CommentNodeID *string `json:"comment_node_id"`
+				Thread        []struct {
+					CommentNodeID *string `json:"comment_node_id"`
+				} `json:"thread"`
+			} `json:"comments"`
+		} `json:"reviews"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatalf("parse json: %v", err)
+	}
+	if len(payload.Reviews) == 0 || len(payload.Reviews[0].Comments) == 0 {
+		t.Fatal("expected comments in report output")
+	}
+	comment := payload.Reviews[0].Comments[0]
+	if comment.CommentNodeID == nil || *comment.CommentNodeID == "" {
+		t.Fatalf("expected comment_node_id to be populated, got %v", comment.CommentNodeID)
+	}
+	if len(comment.Thread) > 0 {
+		if comment.Thread[0].CommentNodeID == nil || *comment.Thread[0].CommentNodeID == "" {
+			t.Fatalf("expected reply comment_node_id populated, got %v", comment.Thread[0].CommentNodeID)
+		}
 	}
 }
 

--- a/cmd/testdata/report_response.json
+++ b/cmd/testdata/report_response.json
@@ -32,6 +32,7 @@
             "comments": {
               "nodes": [
                 {
+                  "id": "C301",
                   "databaseId": 301,
                   "body": "Parent comment 1",
                   "createdAt": "2025-12-03T10:01:00Z",
@@ -44,6 +45,7 @@
                   "replyTo": null
                 },
                 {
+                  "id": "C302",
                   "databaseId": 302,
                   "body": "Reply alpha",
                   "createdAt": "2025-12-03T10:02:00Z",
@@ -53,9 +55,10 @@
                     "state": "APPROVED",
                     "databaseId": 101
                   },
-                  "replyTo": { "databaseId": 301 }
+                  "replyTo": { "id": "C301", "databaseId": 301 }
                 },
                 {
+                  "id": "C303",
                   "databaseId": 303,
                   "body": "Reply beta",
                   "createdAt": "2025-12-03T10:03:00Z",
@@ -65,7 +68,7 @@
                     "state": "APPROVED",
                     "databaseId": 101
                   },
-                  "replyTo": { "databaseId": 302 }
+                  "replyTo": { "id": "C302", "databaseId": 302 }
                 }
               ]
             }
@@ -79,6 +82,7 @@
             "comments": {
               "nodes": [
                 {
+                  "id": "C401",
                   "databaseId": 401,
                   "body": "Parent comment 2",
                   "createdAt": "2025-12-03T10:04:00Z",
@@ -91,6 +95,7 @@
                   "replyTo": null
                 },
                 {
+                  "id": "C402",
                   "databaseId": 402,
                   "body": "Reply gamma",
                   "createdAt": "2025-12-03T10:05:00Z",
@@ -100,7 +105,7 @@
                     "state": "COMMENTED",
                     "databaseId": 202
                   },
-                  "replyTo": { "databaseId": 401 }
+                  "replyTo": { "id": "C401", "databaseId": 401 }
                 }
               ]
             }

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -5,7 +5,7 @@ This guide provides ready-to-run prompts for scripted or agent-driven use of
 include only values present in upstream responses (no null placeholders).
 Empty collections are emitted as `[]` instead of `null`, and the
 `comments reply --concise` mode returns `{ "id" }` when you only need the
-database identifier.
+GraphQL comment identifier.
 
 ## 1. Review a pull request end-to-end
 
@@ -34,8 +34,8 @@ gh pr-review review --submit \
 # GraphQL errors emit:
 # { "status": "Review submission failed", "errors": [ ... ] }
 
-# Summarize reviews and collect comment IDs
-gh pr-review review report --reviewer octocat owner/repo#42
+# Summarize reviews and collect thread IDs
+gh pr-review review report --reviewer octocat --include-comment-node-id owner/repo#42
 ```
 
 > **Note:** `--review-id` always expects the GraphQL review node ID (prefixed
@@ -47,18 +47,27 @@ gh pr-review review report --reviewer octocat owner/repo#42
 ## 2. Read and reply to inline comments
 
 ```sh
-# Capture review threads and comment IDs (GraphQL)
-gh pr-review review report --unresolved owner/repo#42
+# Capture review threads (optionally include comment node IDs)
+gh pr-review review report --unresolved --include-comment-node-id owner/repo#42
 
-# Reply to a comment by database identifier
+# Reply to a thread
 gh pr-review comments reply \
-  --comment-id <comment-id> \
+  --thread-id <thread-id> \
   --body "Thanks for catching this" \
+  owner/repo#42
+
+# Reply to a pending review thread by providing the review ID
+gh pr-review comments reply \
+  --thread-id <thread-id> \
+  --review-id <review-id> \
+  --body "Submitting from pending" \
   owner/repo#42
 ```
 
-Inspect the JSON returned by `review report`, select the desired comment `id`,
-and supply that value as `<comment-id>` when invoking `comments reply`.
+Inspect the JSON returned by `review report`, select the desired `thread_id`
+and, when needed, the `comment_node_id` to correlate individual replies.
+Supply the `thread_id` (and `--review-id` when replying inside a pending
+review) when invoking `comments reply`.
 
 ## 3. Resolve or reopen discussion threads
 

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -1,4 +1,4 @@
-# Output schemas (v1.3.4)
+# Output schemas (v1.4.0)
 
 Optional fields are omitted entirely (never serialized as `null`). Unless noted,
 schemas disallow additional properties to surface unexpected payload changes.
@@ -117,7 +117,7 @@ Emitted by `review report`.
     "ReportComment": {
       "type": "object",
       "required": [
-        "id",
+        "thread_id",
         "path",
         "author_login",
         "body",
@@ -127,9 +127,13 @@ Emitted by `review report`.
         "thread"
       ],
       "properties": {
-        "id": {
-          "type": "integer",
-          "minimum": 1
+        "thread_id": {
+          "type": "string",
+          "description": "GraphQL review thread identifier"
+        },
+        "comment_node_id": {
+          "type": "string",
+          "description": "GraphQL comment node identifier when requested"
         },
         "path": {
           "type": "string"
@@ -167,13 +171,13 @@ Emitted by `review report`.
       "type": "object",
       "required": ["id", "author_login", "body", "created_at"],
       "properties": {
-        "id": {
-          "type": "integer",
-          "minimum": 1
+        "comment_node_id": {
+          "type": "string",
+          "description": "GraphQL comment node identifier when requested"
         },
-        "in_reply_to_id": {
-          "type": ["integer", "null"],
-          "minimum": 1
+        "in_reply_to_comment_node_id": {
+          "type": "string",
+          "description": "GraphQL node ID of the parent comment"
         },
         "author_login": {
           "type": "string"
@@ -196,9 +200,6 @@ Emitted by `review report`.
 
 Default payload from `comments reply`.
 
-This schema captures the stable subset that the extension relies on while
-allowing additional GitHub REST fields to pass through unchanged.
-
 ```json
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -206,36 +207,50 @@ allowing additional GitHub REST fields to pass through unchanged.
   "type": "object",
   "required": [
     "id",
-    "node_id",
-    "pull_request_review_id",
+    "thread_id",
+    "thread_is_resolved",
+    "thread_is_outdated",
     "body",
-    "user",
-    "path",
+    "author_login",
     "html_url",
     "created_at",
     "updated_at"
   ],
   "properties": {
     "id": {
+      "type": "string",
+      "description": "GraphQL comment node identifier"
+    },
+    "database_id": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Numeric comment identifier when persisted"
+    },
+    "review_id": {
+      "type": "string",
+      "description": "GraphQL review identifier when attached to a review"
+    },
+    "review_database_id": {
       "type": "integer",
       "minimum": 1
     },
-    "node_id": {
+    "review_state": {
       "type": "string"
     },
-    "pull_request_review_id": {
-      "type": "integer",
-      "minimum": 1
+    "thread_id": {
+      "type": "string"
     },
-    "in_reply_to_id": {
-      "type": "integer",
-      "minimum": 1
+    "thread_is_resolved": {
+      "type": "boolean"
+    },
+    "thread_is_outdated": {
+      "type": "boolean"
+    },
+    "reply_to_comment_id": {
+      "type": "string"
     },
     "body": {
       "type": "string"
-    },
-    "user": {
-      "$ref": "#/$defs/ReplyUser"
     },
     "diff_hunk": {
       "type": "string"
@@ -243,17 +258,12 @@ allowing additional GitHub REST fields to pass through unchanged.
     "path": {
       "type": "string"
     },
-    "line": {
-      "type": ["integer", "null"],
-      "description": "Replies inside threads may omit diff coordinates"
-    },
-    "side": {
-      "type": ["string", "null"],
-      "enum": ["LEFT", "RIGHT", null]
-    },
     "html_url": {
       "type": "string",
       "format": "uri"
+    },
+    "author_login": {
+      "type": "string"
     },
     "created_at": {
       "type": "string",
@@ -264,23 +274,7 @@ allowing additional GitHub REST fields to pass through unchanged.
       "format": "date-time"
     }
   },
-  "additionalProperties": true,
-  "$defs": {
-    "ReplyUser": {
-      "type": "object",
-      "properties": {
-        "login": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer",
-          "minimum": 1
-        }
-      },
-      "required": ["login", "id"],
-      "additionalProperties": true
-    }
-  }
+  "additionalProperties": false
 }
 ```
 
@@ -296,8 +290,7 @@ Minimal payload from `comments reply --concise`.
   "required": ["id"],
   "properties": {
     "id": {
-      "type": "integer",
-      "minimum": 1
+      "type": "string"
     }
   },
   "additionalProperties": false

--- a/internal/report/builder.go
+++ b/internal/report/builder.go
@@ -96,26 +96,42 @@ func BuildReport(reviews []Review, threads []Thread, filters FilterOptions) Repo
 		reportReplies := make([]ThreadReply, len(replies))
 		for i, reply := range replies {
 			createdAt := reply.CreatedAt.UTC().Format(time.RFC3339)
+			var commentNodeID *string
+			if filters.IncludeCommentNodeID && reply.NodeID != "" {
+				replyID := reply.NodeID
+				commentNodeID = &replyID
+			}
+			var inReplyToNodeID *string
+			if filters.IncludeCommentNodeID && reply.ReplyToCommentNode != nil && *reply.ReplyToCommentNode != "" {
+				replyTo := *reply.ReplyToCommentNode
+				inReplyToNodeID = &replyTo
+			}
 			reportReplies[i] = ThreadReply{
-				ID:          reply.DatabaseID,
-				InReplyToID: reply.ReplyToDatabaseID,
-				AuthorLogin: reply.AuthorLogin,
-				Body:        reply.Body,
-				CreatedAt:   createdAt,
+				CommentNodeID:          commentNodeID,
+				InReplyToCommentNodeID: inReplyToNodeID,
+				AuthorLogin:            reply.AuthorLogin,
+				Body:                   reply.Body,
+				CreatedAt:              createdAt,
 			}
 		}
 
 		createdAt := parent.CreatedAt.UTC().Format(time.RFC3339)
+		var commentNodeID *string
+		if filters.IncludeCommentNodeID && parent.NodeID != "" {
+			id := parent.NodeID
+			commentNodeID = &id
+		}
 		reportComment := ReportComment{
-			ID:          parent.DatabaseID,
-			Path:        thread.Path,
-			Line:        thread.Line,
-			AuthorLogin: parent.AuthorLogin,
-			Body:        parent.Body,
-			CreatedAt:   createdAt,
-			IsResolved:  thread.IsResolved,
-			IsOutdated:  thread.IsOutdated,
-			Thread:      reportReplies,
+			ThreadID:      thread.ID,
+			CommentNodeID: commentNodeID,
+			Path:          thread.Path,
+			Line:          thread.Line,
+			AuthorLogin:   parent.AuthorLogin,
+			Body:          parent.Body,
+			CreatedAt:     createdAt,
+			IsResolved:    thread.IsResolved,
+			IsOutdated:    thread.IsOutdated,
+			Thread:        reportReplies,
 		}
 
 		if len(reportReplies) == 0 {

--- a/internal/report/domain.go
+++ b/internal/report/domain.go
@@ -14,11 +14,12 @@ const (
 
 // FilterOptions controls shaping of reviews and threads.
 type FilterOptions struct {
-	Reviewer           string
-	States             []State
-	RequireUnresolved  bool
-	RequireNotOutdated bool
-	TailReplies        int
+	Reviewer             string
+	States               []State
+	RequireUnresolved    bool
+	RequireNotOutdated   bool
+	TailReplies          int
+	IncludeCommentNodeID bool
 }
 
 // Review models a pull request review fetched from GraphQL.
@@ -43,12 +44,14 @@ type Thread struct {
 
 // ThreadComment represents a single comment node within a thread.
 type ThreadComment struct {
-	DatabaseID        int
-	Body              string
-	CreatedAt         time.Time
-	AuthorLogin       string
-	ReviewDatabaseID  *int
-	ReplyToDatabaseID *int
+	NodeID             string
+	DatabaseID         int
+	Body               string
+	CreatedAt          time.Time
+	AuthorLogin        string
+	ReviewDatabaseID   *int
+	ReplyToDatabaseID  *int
+	ReplyToCommentNode *string
 }
 
 // Report is the serialized output structure for the report command.
@@ -68,22 +71,23 @@ type ReportReview struct {
 
 // ReportComment contains the shaped parent comment for a thread.
 type ReportComment struct {
-	ID          int           `json:"id"`
-	Path        string        `json:"path"`
-	Line        *int          `json:"line,omitempty"`
-	AuthorLogin string        `json:"author_login"`
-	Body        string        `json:"body"`
-	CreatedAt   string        `json:"created_at"`
-	IsResolved  bool          `json:"is_resolved"`
-	IsOutdated  bool          `json:"is_outdated"`
-	Thread      []ThreadReply `json:"thread"`
+	ThreadID      string        `json:"thread_id"`
+	CommentNodeID *string       `json:"comment_node_id,omitempty"`
+	Path          string        `json:"path"`
+	Line          *int          `json:"line,omitempty"`
+	AuthorLogin   string        `json:"author_login"`
+	Body          string        `json:"body"`
+	CreatedAt     string        `json:"created_at"`
+	IsResolved    bool          `json:"is_resolved"`
+	IsOutdated    bool          `json:"is_outdated"`
+	Thread        []ThreadReply `json:"thread"`
 }
 
 // ThreadReply captures a reply within a thread.
 type ThreadReply struct {
-	ID          int    `json:"id"`
-	InReplyToID *int   `json:"in_reply_to_id,omitempty"`
-	AuthorLogin string `json:"author_login"`
-	Body        string `json:"body"`
-	CreatedAt   string `json:"created_at"`
+	CommentNodeID          *string `json:"comment_node_id,omitempty"`
+	InReplyToCommentNodeID *string `json:"in_reply_to_comment_node_id,omitempty"`
+	AuthorLogin            string  `json:"author_login"`
+	Body                   string  `json:"body"`
+	CreatedAt              string  `json:"created_at"`
 }

--- a/internal/report/query.go
+++ b/internal/report/query.go
@@ -30,6 +30,7 @@ const reportQuery = `query Report(
           isOutdated
           comments(first: $firstComments) {
             nodes {
+              id
               databaseId
               body
               createdAt
@@ -40,6 +41,7 @@ const reportQuery = `query Report(
                 databaseId
               }
               replyTo {
+                id
                 databaseId
               }
             }

--- a/internal/report/service_test.go
+++ b/internal/report/service_test.go
@@ -40,14 +40,20 @@ func TestServiceFetchShapesReport(t *testing.T) {
 		t.Fatalf("expected 1 comment, got %d", len(review.Comments))
 	}
 	comment := review.Comments[0]
-	if comment.ID != 301 {
-		t.Fatalf("expected parent comment 301, got %d", comment.ID)
+	if comment.ThreadID != "T1" {
+		t.Fatalf("expected parent thread T1, got %s", comment.ThreadID)
+	}
+	if comment.CommentNodeID != nil {
+		t.Fatalf("expected comment_node_id omitted by default, got %v", comment.CommentNodeID)
 	}
 	if len(comment.Thread) != 1 {
 		t.Fatalf("expected 1 reply after tail filter, got %d", len(comment.Thread))
 	}
-	if comment.Thread[0].ID != 303 {
-		t.Fatalf("expected reply 303, got %d", comment.Thread[0].ID)
+	if comment.Thread[0].Body != "Reply beta" {
+		t.Fatalf("expected reply body 'Reply beta', got %s", comment.Thread[0].Body)
+	}
+	if comment.Thread[0].CommentNodeID != nil {
+		t.Fatalf("expected reply comment_node_id omitted by default, got %v", comment.Thread[0].CommentNodeID)
 	}
 
 	rawStates, ok := fake.lastVariables["states"]
@@ -57,6 +63,38 @@ func TestServiceFetchShapesReport(t *testing.T) {
 	statesVar, ok := rawStates.([]string)
 	if !ok || len(statesVar) != 2 {
 		t.Fatalf("expected states variable propagated as []string, got %#v", rawStates)
+	}
+}
+
+func TestServiceFetchIncludesCommentNodeID(t *testing.T) {
+	fake := &stubAPI{t: t, payload: reportResponseFixture}
+	svc := NewService(fake)
+
+	identity := resolver.Identity{Owner: "agyn", Repo: "sandbox", Number: 51}
+	result, err := svc.Fetch(identity, Options{IncludeCommentNodeID: true})
+	if err != nil {
+		t.Fatalf("fetch report with comment node ids: %v", err)
+	}
+
+	if len(result.Reviews) == 0 {
+		t.Fatal("expected reviews in result")
+	}
+	review := result.Reviews[0]
+	if len(review.Comments) == 0 {
+		t.Fatal("expected comments for review")
+	}
+	comment := review.Comments[0]
+	if comment.CommentNodeID == nil || *comment.CommentNodeID != "C301" {
+		t.Fatalf("expected comment_node_id C301, got %v", comment.CommentNodeID)
+	}
+	if len(comment.Thread) == 0 {
+		t.Fatal("expected replies to be present")
+	}
+	if comment.Thread[0].CommentNodeID == nil || *comment.Thread[0].CommentNodeID == "" {
+		t.Fatalf("expected reply comment node id, got %v", comment.Thread[0].CommentNodeID)
+	}
+	if comment.Thread[0].InReplyToCommentNodeID == nil || *comment.Thread[0].InReplyToCommentNodeID == "" {
+		t.Fatalf("expected reply to include in_reply_to_comment_node_id, got %v", comment.Thread[0].InReplyToCommentNodeID)
 	}
 }
 

--- a/internal/report/testdata/report_response.json
+++ b/internal/report/testdata/report_response.json
@@ -32,79 +32,84 @@
             "comments": {
               "nodes": [
                 {
-                  "databaseId": 301,
-                  "body": "Parent comment 1",
-                  "createdAt": "2025-12-03T10:01:00Z",
-                  "author": { "login": "alice" },
-                  "pullRequestReview": {
-                    "id": "R1",
-                    "state": "APPROVED",
-                    "databaseId": 101
-                  },
-                  "replyTo": null
-                },
-                {
-                  "databaseId": 302,
-                  "body": "Reply alpha",
-                  "createdAt": "2025-12-03T10:02:00Z",
-                  "author": { "login": "bob" },
-                  "pullRequestReview": {
-                    "id": "R1",
-                    "state": "APPROVED",
-                    "databaseId": 101
-                  },
-                  "replyTo": { "databaseId": 301 }
-                },
-                {
-                  "databaseId": 303,
-                  "body": "Reply beta",
-                  "createdAt": "2025-12-03T10:03:00Z",
-                  "author": { "login": "alice" },
-                  "pullRequestReview": {
-                    "id": "R1",
-                    "state": "APPROVED",
-                    "databaseId": 101
-                  },
-                  "replyTo": { "databaseId": 302 }
-                }
-              ]
+              "id": "C301",
+              "databaseId": 301,
+              "body": "Parent comment 1",
+              "createdAt": "2025-12-03T10:01:00Z",
+              "author": { "login": "alice" },
+              "pullRequestReview": {
+                "id": "R1",
+                "state": "APPROVED",
+                "databaseId": 101
+              },
+              "replyTo": null
+            },
+            {
+              "id": "C302",
+              "databaseId": 302,
+              "body": "Reply alpha",
+              "createdAt": "2025-12-03T10:02:00Z",
+              "author": { "login": "bob" },
+              "pullRequestReview": {
+                "id": "R1",
+                "state": "APPROVED",
+                "databaseId": 101
+              },
+              "replyTo": { "id": "C301", "databaseId": 301 }
+            },
+            {
+              "id": "C303",
+              "databaseId": 303,
+              "body": "Reply beta",
+              "createdAt": "2025-12-03T10:03:00Z",
+              "author": { "login": "alice" },
+              "pullRequestReview": {
+                "id": "R1",
+                "state": "APPROVED",
+                "databaseId": 101
+              },
+              "replyTo": { "id": "C302", "databaseId": 302 }
             }
-          },
-          {
-            "id": "T2",
-            "path": "main.go",
-            "line": null,
-            "isResolved": true,
-            "isOutdated": true,
-            "comments": {
-              "nodes": [
-                {
-                  "databaseId": 401,
-                  "body": "Parent comment 2",
-                  "createdAt": "2025-12-03T10:04:00Z",
-                  "author": { "login": "bob" },
-                  "pullRequestReview": {
-                    "id": "R2",
-                    "state": "COMMENTED",
-                    "databaseId": 202
-                  },
-                  "replyTo": null
-                },
-                {
-                  "databaseId": 402,
-                  "body": "Reply gamma",
-                  "createdAt": "2025-12-03T10:05:00Z",
-                  "author": { "login": "alice" },
-                  "pullRequestReview": {
-                    "id": "R2",
-                    "state": "COMMENTED",
-                    "databaseId": 202
-                  },
-                  "replyTo": { "databaseId": 401 }
-                }
-              ]
+          ]
+        }
+      },
+      {
+        "id": "T2",
+        "path": "main.go",
+        "line": null,
+        "isResolved": true,
+        "isOutdated": true,
+        "comments": {
+          "nodes": [
+            {
+              "id": "C401",
+              "databaseId": 401,
+              "body": "Parent comment 2",
+              "createdAt": "2025-12-03T10:04:00Z",
+              "author": { "login": "bob" },
+              "pullRequestReview": {
+                "id": "R2",
+                "state": "COMMENTED",
+                "databaseId": 202
+              },
+              "replyTo": null
+            },
+            {
+              "id": "C402",
+              "databaseId": 402,
+              "body": "Reply gamma",
+              "createdAt": "2025-12-03T10:05:00Z",
+              "author": { "login": "alice" },
+              "pullRequestReview": {
+                "id": "R2",
+                "state": "COMMENTED",
+                "databaseId": 202
+              },
+              "replyTo": { "id": "C401", "databaseId": 401 }
             }
-          }
+          ]
+        }
+      }
         ]
       }
     }


### PR DESCRIPTION
## Summary
- migrate comment replies to GraphQL thread reply mutation with structured response data
- extend review report domain to emit thread ids and optional comment node ids surfaced by a new flag
- refresh CLI docs, schemas, and release notes for v1.4.0 and drop REST reply fixtures

Resolves #62.

## Testing
- go test ./...
- go vet ./...
- GOOS=linux GOARCH=arm64 go build -buildvcs=false ./...
- go run . review report agyn-sandbox/gh-pr-review-e2e-tmp-20251203#3 --include-comment-node-id
