### PR TITLE
feat: enforce graphql-only thread workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ and resolves discussions without cloning repositories.
 - [Review report](#review-report)
 - [Backend policy](#backend-policy)
 - [Additional docs](#additional-docs)
-- [Release 1.4.0](#release-140)
+- [Release 1.5.0](#release-150)
 
 ## Quickstart
 
@@ -141,13 +141,12 @@ The quickest path from opening a pending review to resolving threads:
      }
    ]
 
-   gh pr-review threads resolve --thread-id R_ywDoABC123 owner/repo#42
+gh pr-review threads resolve --thread-id R_ywDoABC123 owner/repo#42
 
-   {
-     "threadId": "R_ywDoABC123",
-     "isResolved": true,
-     "changed": true
-   }
+{
+  "thread_node_id": "R_ywDoABC123",
+  "is_resolved": true
+}
    ```
 
 ## Review report
@@ -162,8 +161,7 @@ Run it with either a combined selector or explicit flags:
 gh pr-review review report -R owner/repo --pr 3
 ```
 
-Install or upgrade to **v1.4.0 or newer** (adds thread IDs and optional comment
-node IDs in the report output):
+Install or upgrade to **v1.5.0 or newer** (GraphQL-only thread resolution and minimal comment replies):
 
 ```sh
 gh extension install Agyn-sandbox/gh-pr-review
@@ -272,17 +270,13 @@ Each command binds to a single GitHub backend—there are no runtime fallbacks.
 | `review --submit` | GraphQL | Finalizes a pending review via `submitPullRequestReview` using the `PRR_…` review node ID (executed through the internal `gh api graphql` wrapper). |
 | `comments reply` | GraphQL | Replies via `addPullRequestReviewThreadReply`; supply `--review-id` when responding from a pending review. |
 | `threads list` | GraphQL | Enumerates review threads for the pull request. |
-| `threads resolve` / `unresolve` | GraphQL (+ REST when mapping `--comment-id`) | Mutates thread resolution with GraphQL; a REST lookup translates numeric comment IDs to node IDs. |
-| `threads find` | GraphQL (+ REST when mapping `--comment_id`) | Returns `{ "id", "isResolved" }`. |
-
-> Note: Some flows, such as mapping numeric comment IDs for thread resolution,
-> still perform REST lookups. Mutation operations themselves are GraphQL-based.
+| `threads resolve` / `unresolve` | GraphQL | Mutates thread resolution via `resolveReviewThread` / `unresolveReviewThread`; supply GraphQL thread node IDs (`PRRT_…`). |
 
 
 ## Additional docs
 
 - [docs/USAGE.md](docs/USAGE.md) — Command-by-command inputs, outputs, and
-  examples for v1.4.0.
+  examples for v1.5.0.
 - [docs/SCHEMAS.md](docs/SCHEMAS.md) — JSON schemas for each structured
   response (optional fields omitted rather than set to null).
 - [docs/AGENTS.md](docs/AGENTS.md) — Agent-focused workflows, prompts, and
@@ -311,12 +305,13 @@ Releases are built using the
 [`cli/gh-extension-precompile`](https://github.com/cli/gh-extension-precompile)
 workflow to publish binaries for macOS, Linux, and Windows.
 
-## Release 1.4.0
+## Release 1.5.0
 
-- `review report` now surfaces GraphQL `thread_id` values by default and can
-  optionally emit per-comment `comment_node_id` fields via
-  `--include-comment-node-id`.
-- `comments reply` is fully GraphQL-based, accepts `--thread-id` (and optional
-  `--review-id` for pending reviews), and returns structured thread metadata.
+- `threads resolve` / `threads unresolve` now exclusively accept GraphQL thread
+  node IDs and emit minimal JSON `{ "thread_node_id": "…", "is_resolved": true|false }`.
+- Removed the legacy `threads find` command and the `--comment-id` lookup path
+  used to translate REST comment identifiers.
+- `comments reply` always returns the minimal `{ "comment_node_id": "PRRC_…" }`
+  payload; the `--concise` flag has been removed.
 - Documentation updates cover the new flag, reply payload, and schema changes
   required for this release.

--- a/cmd/comments.go
+++ b/cmd/comments.go
@@ -64,7 +64,6 @@ func newCommentsReplyCommand(parent *commentsOptions) *cobra.Command {
 	cmd.Flags().StringVar(&opts.ThreadID, "thread-id", "", "Review thread identifier to reply to")
 	cmd.Flags().StringVar(&opts.ReviewID, "review-id", "", "GraphQL review identifier when replying inside a pending review")
 	cmd.Flags().StringVar(&opts.Body, "body", "", "Reply text")
-	cmd.Flags().BoolVar(&opts.Concise, "concise", false, "Emit minimal reply payload { \"id\" }")
 	_ = cmd.MarkFlagRequired("thread-id")
 	_ = cmd.MarkFlagRequired("body")
 
@@ -78,7 +77,6 @@ type commentsReplyOptions struct {
 	ThreadID string
 	ReviewID string
 	Body     string
-	Concise  bool
 }
 
 func runCommentsReply(cmd *cobra.Command, opts *commentsReplyOptions) error {
@@ -103,11 +101,8 @@ func runCommentsReply(cmd *cobra.Command, opts *commentsReplyOptions) error {
 	if err != nil {
 		return err
 	}
-	if opts.Concise {
-		if reply.CommentNodeID == "" {
-			return errors.New("reply response missing comment node id")
-		}
-		return encodeJSON(cmd, map[string]string{"comment_node_id": reply.CommentNodeID})
+	if reply.CommentNodeID == "" {
+		return errors.New("reply response missing comment node id")
 	}
-	return encodeJSON(cmd, reply)
+	return encodeJSON(cmd, map[string]string{"comment_node_id": reply.CommentNodeID})
 }

--- a/cmd/comments_test.go
+++ b/cmd/comments_test.go
@@ -124,23 +124,11 @@ func TestCommentsReplyCommand(t *testing.T) {
 
 	var payload map[string]interface{}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &payload))
+	require.Len(t, payload, 1)
 	assert.Equal(t, "PRRC_reply", payload["comment_node_id"])
-	assert.Equal(t, "ack", payload["body"])
-	assert.Equal(t, "PRRT_thread", payload["thread_id"])
-	assert.Equal(t, "octocat", payload["author_login"])
-	assert.Equal(t, "https://example.com/comment", payload["html_url"])
-	assert.Equal(t, "internal/service.go", payload["path"])
-	assert.Equal(t, float64(101), payload["database_id"])
-	assert.Equal(t, "@@ -10,5 +10,7 @@", payload["diff_hunk"])
-	assert.Equal(t, false, payload["thread_is_resolved"])
-	assert.Equal(t, false, payload["thread_is_outdated"])
-	assert.Equal(t, "PRRC_parent", payload["reply_to_comment_id"])
-	assert.Equal(t, "PRR_pending", payload["review_id"])
-	assert.Equal(t, float64(202), payload["review_database_id"])
-	assert.Equal(t, "PENDING", payload["review_state"])
 }
 
-func TestCommentsReplyCommandConcise(t *testing.T) {
+func TestCommentsReplyCommandWithoutReviewID(t *testing.T) {
 	originalFactory := apiClientFactory
 	defer func() { apiClientFactory = originalFactory }()
 
@@ -204,7 +192,7 @@ func TestCommentsReplyCommandConcise(t *testing.T) {
 	stderr := &bytes.Buffer{}
 	root.SetOut(stdout)
 	root.SetErr(stderr)
-	root.SetArgs([]string{"comments", "reply", "--thread-id", "PRRT_thread", "--body", "ack", "--concise", "octo/demo#7"})
+	root.SetArgs([]string{"comments", "reply", "--thread-id", "PRRT_thread", "--body", "ack", "octo/demo#7"})
 
 	err := root.Execute()
 	require.NoError(t, err)
@@ -212,7 +200,7 @@ func TestCommentsReplyCommandConcise(t *testing.T) {
 
 	var payload map[string]interface{}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &payload))
-	assert.Equal(t, 1, len(payload))
+	require.Len(t, payload, 1)
 	assert.Equal(t, "PRRC_reply", payload["comment_node_id"])
 }
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -3,9 +3,8 @@
 This guide provides ready-to-run prompts for scripted or agent-driven use of
 `gh pr-review`. All commands emit JSON with REST/GraphQL-aligned field names and
 include only values present in upstream responses (no null placeholders).
-Empty collections are emitted as `[]` instead of `null`, and the
-`comments reply --concise` mode returns `{ "id" }` when you only need the
-GraphQL comment identifier.
+Empty collections are emitted as `[]` instead of `null`; `comments reply`
+returns `{ "comment_node_id": "PRRC_…" }` for minimal responses.
 
 ## 1. Review a pull request end-to-end
 
@@ -72,17 +71,14 @@ review) when invoking `comments reply`.
 ## 3. Resolve or reopen discussion threads
 
 ```sh
-# Locate the thread for a specific comment; emits { "id", "isResolved" }
-gh pr-review threads find --comment_id 2582545223 owner/repo#42
-
-# Resolve the thread
+# Resolve the thread using its GraphQL node ID
 gh pr-review threads resolve --thread-id <thread-id> owner/repo#42
 
 # Reopen the thread if needed
 gh pr-review threads unresolve --thread-id <thread-id> owner/repo#42
 ```
 
-Take the `id` returned by `threads find` and reuse it as `<thread-id>` with
-`threads resolve` or `threads unresolve`. Responses remain JSON-only with
-GitHub-aligned field names and include only fields surfaced by the upstream
-APIs. Threads can also be resolved directly via `--comment-id` if preferred.
+Use `review report` (optionally with `--include-comment-node-id`) or
+`threads list` to gather `thread_id` values before mutating them. Thread
+mutations return minimal JSON of the form
+`{ "thread_node_id": "PRRT_…", "is_resolved": true|false }`.

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -1,4 +1,4 @@
-# Output schemas (v1.4.0)
+# Output schemas (v1.5.0)
 
 Optional fields are omitted entirely (never serialized as `null`). Unless noted,
 schemas disallow additional properties to surface unexpected payload changes.
@@ -192,101 +192,20 @@ Emitted by `review report`.
 }
 ```
 
-## ReplyComment
+## ReplyMinimal
 
-Default payload from `comments reply`.
-
-```json
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "ReplyComment",
-  "type": "object",
-  "required": [
-    "comment_node_id",
-    "thread_id",
-    "thread_is_resolved",
-    "thread_is_outdated",
-    "body",
-    "author_login",
-    "html_url",
-    "created_at",
-    "updated_at"
-  ],
-  "properties": {
-    "comment_node_id": {
-      "type": "string",
-      "description": "GraphQL comment node identifier"
-    },
-    "database_id": {
-      "type": "integer",
-      "minimum": 1,
-      "description": "Numeric comment identifier when persisted"
-    },
-    "review_id": {
-      "type": "string",
-      "description": "GraphQL review identifier when attached to a review"
-    },
-    "review_database_id": {
-      "type": "integer",
-      "minimum": 1
-    },
-    "review_state": {
-      "type": "string"
-    },
-    "thread_id": {
-      "type": "string"
-    },
-    "thread_is_resolved": {
-      "type": "boolean"
-    },
-    "thread_is_outdated": {
-      "type": "boolean"
-    },
-    "reply_to_comment_id": {
-      "type": "string"
-    },
-    "body": {
-      "type": "string"
-    },
-    "diff_hunk": {
-      "type": "string"
-    },
-    "path": {
-      "type": "string"
-    },
-    "html_url": {
-      "type": "string",
-      "format": "uri"
-    },
-    "author_login": {
-      "type": "string"
-    },
-    "created_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    }
-  },
-  "additionalProperties": false
-}
-```
-
-## ReplyConcise
-
-Minimal payload from `comments reply --concise`.
+Returned by `comments reply`.
 
 ```json
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "ReplyConcise",
+  "title": "ReplyMinimal",
   "type": "object",
   "required": ["comment_node_id"],
   "properties": {
     "comment_node_id": {
-      "type": "string"
+      "type": "string",
+      "description": "GraphQL comment node identifier"
     }
   },
   "additionalProperties": false
@@ -333,48 +252,21 @@ Returned by `threads list`.
 }
 ```
 
-## ThreadActionResult
+## ThreadMutationResult
 
-Emitted by `threads resolve` and `threads unresolve`.
-
-```json
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "ThreadActionResult",
-  "type": "object",
-  "required": ["threadId", "isResolved", "changed"],
-  "properties": {
-    "threadId": {
-      "type": "string"
-    },
-    "isResolved": {
-      "type": "boolean"
-    },
-    "changed": {
-      "type": "boolean",
-      "description": "False when the thread already matched the requested state"
-    }
-  },
-  "additionalProperties": false
-}
-```
-
-## ThreadFindResult
-
-Returned by `threads find` and used internally when mapping REST comment IDs to
-GraphQL threads.
+Returned by `threads resolve` and `threads unresolve`.
 
 ```json
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "ThreadFindResult",
+  "title": "ThreadMutationResult",
   "type": "object",
-  "required": ["id", "isResolved"],
+  "required": ["thread_node_id", "is_resolved"],
   "properties": {
-    "id": {
+    "thread_node_id": {
       "type": "string"
     },
-    "isResolved": {
+    "is_resolved": {
       "type": "boolean"
     }
   },


### PR DESCRIPTION
## Summary
- require GraphQL thread node IDs for resolve/unresolve and remove `threads find`
- simplify `comments reply` output to `{ "comment_node_id": "…" }` and drop `--concise`
- update docs for v1.5.0 and confirm linux/arm64 release targets

## Testing
- CGO_ENABLED=0 go test ./...
- GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build ./...

Resolves #69.
