### PR TITLE
feat/comment-node-id-review-schema: enforce reply schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ gh pr-review review view -R owner/repo --pr 3 --not_outdated --include-comment-n
           "created_at": "…",
           "is_resolved": true,
           "is_outdated": false,
-          "thread": [         // replies only; sorted asc; tail applies
+          "thread_comments": [         // replies only; sorted asc; tail applies
             {
               "comment_node_id": "PRRC_…",  // omitted unless requested
               "author_login": "…",

--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ The quickest path from opening a pending review to resolving threads:
          "id": "PRR_kwDOAAABbcdEFG12",
          "state": "COMMENTED",
          "comments": [
-           {
-             "thread_id": "PRRT_kwDOAAABbcdEFG12",
-             "path": "internal/service.go",
-             "body": "nit: prefer helper",
+          {
+            "thread_id": "PRRT_kwDOAAABbcdEFG12",
+            "path": "internal/service.go",
+            "body": "nit: prefer helper",
             "is_resolved": false,
             "is_outdated": false,
             "thread_comments": []

--- a/README.md
+++ b/README.md
@@ -85,12 +85,12 @@ The quickest path from opening a pending review to resolving threads:
              "thread_id": "PRRT_kwDOAAABbcdEFG12",
              "path": "internal/service.go",
              "body": "nit: prefer helper",
-             "is_resolved": false,
-             "is_outdated": false,
-             "thread": []
-           }
-         ]
-       }
+            "is_resolved": false,
+            "is_outdated": false,
+            "thread_comments": []
+          }
+        ]
+      }
      ]
    }
    ```
@@ -315,4 +315,3 @@ CGO_ENABLED=0 golangci-lint run
 Releases are built using the
 [`cli/gh-extension-precompile`](https://github.com/cli/gh-extension-precompile)
 workflow to publish binaries for macOS, Linux, and Windows.
-

--- a/cmd/comments_test.go
+++ b/cmd/comments_test.go
@@ -126,6 +126,8 @@ func TestCommentsReplyCommand(t *testing.T) {
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &payload))
 	require.Len(t, payload, 1)
 	assert.Equal(t, "PRRC_reply", payload["comment_node_id"])
+	_, hasLegacyID := payload["id"]
+	assert.False(t, hasLegacyID, "reply payload should not include legacy id field")
 }
 
 func TestCommentsReplyCommandWithoutReviewID(t *testing.T) {
@@ -202,6 +204,8 @@ func TestCommentsReplyCommandWithoutReviewID(t *testing.T) {
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &payload))
 	require.Len(t, payload, 1)
 	assert.Equal(t, "PRRC_reply", payload["comment_node_id"])
+	_, hasLegacyID := payload["id"]
+	assert.False(t, hasLegacyID, "reply payload should not include legacy id field")
 }
 
 func assignJSON(result interface{}, payload interface{}) error {

--- a/cmd/review_view_test.go
+++ b/cmd/review_view_test.go
@@ -83,6 +83,9 @@ func TestReviewViewCommandFiltersOutput(t *testing.T) {
 	if comment.ThreadComments[0].CommentNodeID != nil {
 		t.Fatalf("expected reply comment_node_id omitted by default, got %v", *comment.ThreadComments[0].CommentNodeID)
 	}
+	if strings.Contains(buf.String(), "in_reply_to_comment_node_id") {
+		t.Fatal("expected replies to omit in_reply_to_comment_node_id")
+	}
 
 	rawStates, ok := fake.variables["states"].([]string)
 	if !ok || len(rawStates) != 2 {
@@ -146,6 +149,9 @@ func TestReviewViewCommandIncludesCommentNodeID(t *testing.T) {
 		if comment.ThreadComments[0].CommentNodeID == nil || *comment.ThreadComments[0].CommentNodeID == "" {
 			t.Fatalf("expected reply comment_node_id populated, got %v", comment.ThreadComments[0].CommentNodeID)
 		}
+	}
+	if strings.Contains(buf.String(), "in_reply_to_comment_node_id") {
+		t.Fatal("expected replies to omit in_reply_to_comment_node_id when including node ids")
 	}
 }
 

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -169,7 +169,7 @@ Emitted by `review view`.
     },
     "ThreadReply": {
       "type": "object",
-      "required": ["id", "author_login", "body", "created_at"],
+      "required": ["author_login", "body", "created_at"],
       "properties": {
         "comment_node_id": {
           "type": "string",

--- a/internal/report/builder_test.go
+++ b/internal/report/builder_test.go
@@ -169,6 +169,9 @@ func TestBuildReportAggregatesThreads(t *testing.T) {
 	if strings.Contains(string(jsonBytes), `"body":""`) {
 		t.Fatal("expected empty body fields to be omitted from JSON")
 	}
+	if strings.Contains(string(jsonBytes), "in_reply_to_comment_node_id") {
+		t.Fatal("expected replies to omit in_reply_to_comment_node_id")
+	}
 }
 
 func TestBuildReportFilterOptions(t *testing.T) {


### PR DESCRIPTION
## Summary
- ensure reply command output only emits comment_node_id
- assert review reports omit in_reply_to_comment_node_id and update schema docs

## Testing
- CGO_ENABLED=0 go test ./...
- CGO_ENABLED=0 golangci-lint run
- CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o dist/linux-arm64/gh-pr-review

Fixes #66